### PR TITLE
Use Composable-scoped `ViewModelStoreOwner`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 10.0.0-beta04 (unreleased)
+# 10.0.0-beta04
 - [Android] Fix bug where Composable state did not get reset 
 
 # 10.0.0-beta03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 10.0.0-beta04 (unreleased)
+- [Android] Fix bug where Composable state did not get reset 
+
 # 10.0.0-beta03
 - Allow setEnvironment({required bool useSandbox}) to enable sandbox or production environment
 - Allow setCallbackUrl({required Uri callbackUrl}) to set a callback url for all submitted jobs.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,6 +61,7 @@ android {
         implementation "com.smileidentity:android-sdk:${version}"
         implementation "androidx.core:core-ktx"
         implementation "androidx.compose.ui:ui"
+        implementation 'androidx.lifecycle:lifecycle-viewmodel-compose'
         implementation "androidx.compose.material3:material3"
         implementation "androidx.fragment:fragment-ktx"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core"

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileComposablePlatformView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileComposablePlatformView.kt
@@ -1,0 +1,98 @@
+package com.smileidentity.flutter
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.ComposeView
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.smileidentity.SmileID
+import io.flutter.Log
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.platform.PlatformView
+
+/**
+ * Base class for hosting Smile ID Composables in Flutter. This class handles flutter<>android
+ * result delivery, view initialization (incl. view model store), and boilerplate. Subclasses
+ * should implement [Content] to provide the actual Composable content.
+ */
+internal abstract class SmileComposablePlatformView(
+    context: Context,
+    viewTypeId: String,
+    viewId: Int,
+    messenger: BinaryMessenger,
+    args: Map<String, Any?>,
+) : PlatformView {
+
+    private val methodChannel = MethodChannel(messenger, "${viewTypeId}_$viewId")
+
+    // Creates a viewModelStore that is scoped to the FlutterView's lifecycle. Otherwise, state gets
+    // shared between multiple FlutterView instances since the default viewModelStore is at the
+    // Activity level and since we don't have a full Compose app or nav graph, the same viewModel
+    // ends up getting re-used
+    private var view: ComposeView? = ComposeView(context).apply {
+        setContent {
+            CompositionLocalProvider(
+                LocalViewModelStoreOwner provides object : ViewModelStoreOwner {
+                    override val viewModelStore = ViewModelStore()
+                }
+            ) {
+                Content(args)
+            }
+        }
+    }
+
+    /**
+     * Implement this method to provide the actual Composable content for the view
+     *
+     * @param args The arguments passed from Flutter. It is the responsibility of the subclass to
+     * ensure the correct types are provided by the Flutter view and that they are parsed correctly
+     */
+    @Composable
+    abstract fun Content(args: Map<String, Any?>)
+
+    /**
+     * Delivers a successful result back to Flutter as JSON. It is the flutter code's responsibility
+     * to parse this JSON string into the appropriate object
+     *
+     * @param result The success result object. NB! This object *must* be serializable by the
+     * [SmileID.moshi] instance!
+     */
+    inline fun <reified T> onSuccess(result: T) {
+        // At this point, we have a successful result from the native SDK. But, there is still a
+        // possibility of the JSON serializing erroring for whatever reason -- if such a thing
+        // happens, we still want to tell the caller that the overall operation was successful.
+        // However, we just may not be able to provide the result JSON.
+        val json = try {
+            SmileID.moshi
+                .adapter(T::class.java)
+                .toJson(result)
+        } catch (e: Exception) {
+            Log.e("SmileComposablePlatformView", "Error serializing result", e)
+            Log.v("SmileComposablePlatformView", "Result is: $result")
+            "null"
+        }
+        methodChannel.invokeMethod("onSuccess", json)
+    }
+
+    /**
+     * Delivers an error result back to Flutter
+     *
+     * @param throwable The throwable that caused the error. This will be converted to a string
+     * message and delivered back to Flutter, because a [Throwable] cannot be passed back to Flutter
+     */
+    fun onError(throwable: Throwable) {
+        // Print the stack trace, since we can't provide the actual Throwable back to Flutter
+        throwable.printStackTrace()
+        methodChannel.invokeMethod("onError", throwable.message)
+    }
+
+    override fun getView() = view
+
+    override fun dispose() {
+        // Clear references to the view to avoid memory leaks
+        view = null
+    }
+}

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileComposablePlatformView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileComposablePlatformView.kt
@@ -15,8 +15,8 @@ import io.flutter.plugin.platform.PlatformView
 
 /**
  * Base class for hosting Smile ID Composables in Flutter. This class handles flutter<>android
- * result delivery, view initialization (incl. view model store), and boilerplate. Subclasses
- * should implement [Content] to provide the actual Composable content.
+ * result delivery, view initialization (incl. view model store), and boilerplate. Subclasses should
+ * implement [Content] to provide the actual Composable content.
  */
 internal abstract class SmileComposablePlatformView(
     context: Context,
@@ -28,17 +28,19 @@ internal abstract class SmileComposablePlatformView(
 
     private val methodChannel = MethodChannel(messenger, "${viewTypeId}_$viewId")
 
-    // Creates a viewModelStore that is scoped to the FlutterView's lifecycle. Otherwise, state gets
-    // shared between multiple FlutterView instances since the default viewModelStore is at the
-    // Activity level and since we don't have a full Compose app or nav graph, the same viewModel
-    // ends up getting re-used
+    /**
+     * Creates a viewModelStore that is scoped to the FlutterView's lifecycle. Otherwise, state gets
+     * shared between multiple FlutterView instances since the default viewModelStore is at the
+     * Activity level and since we don't have a full Compose app or nav graph, the same viewModel
+     * ends up getting re-used
+     */
+    private val viewModelStoreOwner = object : ViewModelStoreOwner {
+        override val viewModelStore = ViewModelStore()
+    }
+
     private var view: ComposeView? = ComposeView(context).apply {
         setContent {
-            CompositionLocalProvider(
-                LocalViewModelStoreOwner provides object : ViewModelStoreOwner {
-                    override val viewModelStore = ViewModelStore()
-                }
-            ) {
+            CompositionLocalProvider(LocalViewModelStoreOwner provides viewModelStoreOwner) {
                 Content(args)
             }
         }

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentVerification.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentVerification.kt
@@ -1,17 +1,13 @@
 package com.smileidentity.flutter
 
 import android.content.Context
-import android.view.View
-import androidx.compose.ui.platform.ComposeView
+import androidx.compose.runtime.Composable
 import com.smileidentity.SmileID
 import com.smileidentity.compose.DocumentVerification
-import com.smileidentity.results.DocumentVerificationResult
 import com.smileidentity.results.SmileIDResult
 import com.smileidentity.util.randomJobId
 import com.smileidentity.util.randomUserId
-import io.flutter.Log
 import io.flutter.plugin.common.BinaryMessenger
-import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
@@ -22,64 +18,32 @@ internal class SmileIDDocumentVerification private constructor(
     viewId: Int,
     messenger: BinaryMessenger,
     args: Map<String, Any?>,
-) : PlatformView {
+) : SmileComposablePlatformView(context, VIEW_TYPE_ID, viewId, messenger, args) {
     companion object {
         const val VIEW_TYPE_ID = "SmileIDDocumentVerification"
     }
 
-    private val methodChannel: MethodChannel
-    private val view: View
-
-    init {
-        methodChannel = MethodChannel(messenger, "${VIEW_TYPE_ID}_$viewId")
-        view = ComposeView(context).apply {
-            setContent {
-                SmileID.DocumentVerification(
-                    countryCode = args["countryCode"] as String,
-                    documentType = args["documentType"] as? String,
-                    idAspectRatio = (args["idAspectRatio"] as Double?)?.toFloat(),
-                    captureBothSides = args["captureBothSides"] as? Boolean ?: true,
-                    bypassSelfieCaptureWithFile =
-                    (args["bypassSelfieCaptureWithFile"] as? String)?.let { File(it) },
-                    userId = args["userId"] as? String ?: randomUserId(),
-                    jobId = args["jobId"] as? String ?: randomJobId(),
-                    showAttribution = args["showAttribution"] as? Boolean ?: true,
-                    allowGalleryUpload = args["allowGalleryUpload"] as? Boolean ?: false,
-                    showInstructions = args["showInstructions"] as? Boolean ?: true,
-                ) {
-                    when (it) {
-                        is SmileIDResult.Success -> {
-                            // At this point, we have a successful result from the native SDK. But,
-                            // there is still a possibility of the JSON serializing erroring for
-                            // whatever reason -- if such a thing happens, we still want to tell
-                            // the caller that the overall operation was successful. However, we
-                            // just may not be able to provide the result JSON.
-                            val json = try {
-                                SmileID.moshi
-                                    .adapter(DocumentVerificationResult::class.java)
-                                    .toJson(it.data)
-                            } catch (e: Exception) {
-                                Log.e("SmileIDDocumentVerification", "Error serializing result", e)
-                                "null"
-                            }
-                            methodChannel.invokeMethod("onSuccess", json)
-                        }
-
-                        is SmileIDResult.Error -> {
-                            // Print the stack trace, since we can't provide the actual Throwable
-                            // back to Flutter
-                            it.throwable.printStackTrace()
-                            methodChannel.invokeMethod("onError", it.throwable.message)
-                        }
-                    }
-                }
+    @Composable
+    override fun Content(args: Map<String, Any?>) {
+        SmileID.DocumentVerification(
+            countryCode = args["countryCode"] as String,
+            documentType = args["documentType"] as? String,
+            idAspectRatio = (args["idAspectRatio"] as Double?)?.toFloat(),
+            captureBothSides = args["captureBothSides"] as? Boolean ?: true,
+            bypassSelfieCaptureWithFile =
+            (args["bypassSelfieCaptureWithFile"] as? String)?.let { File(it) },
+            userId = args["userId"] as? String ?: randomUserId(),
+            jobId = args["jobId"] as? String ?: randomJobId(),
+            showAttribution = args["showAttribution"] as? Boolean ?: true,
+            allowGalleryUpload = args["allowGalleryUpload"] as? Boolean ?: false,
+            showInstructions = args["showInstructions"] as? Boolean ?: true,
+        ) {
+            when (it) {
+                is SmileIDResult.Success -> onSuccess(it.data)
+                is SmileIDResult.Error -> onError(it.throwable)
             }
         }
     }
-
-    override fun getView() = view
-
-    override fun dispose() = Unit
 
     class Factory(
         private val messenger: BinaryMessenger,

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieAuthentication.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieAuthentication.kt
@@ -1,17 +1,13 @@
 package com.smileidentity.flutter
 
 import android.content.Context
-import android.view.View
-import androidx.compose.ui.platform.ComposeView
+import androidx.compose.runtime.Composable
 import com.smileidentity.SmileID
 import com.smileidentity.compose.SmartSelfieAuthentication
-import com.smileidentity.results.SmartSelfieResult
 import com.smileidentity.results.SmileIDResult
 import com.smileidentity.util.randomJobId
 import com.smileidentity.util.randomUserId
-import io.flutter.Log
 import io.flutter.plugin.common.BinaryMessenger
-import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
@@ -21,61 +17,25 @@ internal class SmileIDSmartSelfieAuthentication private constructor(
     viewId: Int,
     messenger: BinaryMessenger,
     args: Map<String, Any?>,
-) : PlatformView {
+) : SmileComposablePlatformView(context, VIEW_TYPE_ID, viewId, messenger, args) {
     companion object {
         const val VIEW_TYPE_ID = "SmileIDSmartSelfieAuthentication"
     }
 
-    private val methodChannel: MethodChannel
-    private val view: View
-
-    init {
-        methodChannel = MethodChannel(messenger, "${VIEW_TYPE_ID}_$viewId")
-        view = ComposeView(context).apply {
-            setContent {
-                SmileID.SmartSelfieAuthentication(
-                    userId = args["userId"] as? String ?: randomUserId(),
-                    jobId = args["jobId"] as? String ?: randomJobId(),
-                    allowAgentMode = args["allowAgentMode"] as? Boolean ?: false,
-                    showAttribution = args["showAttribution"] as? Boolean ?: true,
-                ) {
-                    when (it) {
-                        is SmileIDResult.Success -> {
-                            // At this point, we have a successful result from the native SDK. But,
-                            // there is still a possibility of the JSON serializing erroring for
-                            // whatever reason -- if such a thing happens, we still want to tell
-                            // the caller that the overall operation was successful. However, we
-                            // just may not be able to provide the result JSON.
-                            val json = try {
-                                SmileID.moshi
-                                    .adapter(SmartSelfieResult::class.java)
-                                    .toJson(it.data)
-                            } catch (e: Exception) {
-                                Log.e(
-                                    "SmileIDSmartSelfieAuthentication",
-                                    "Error serializing result",
-                                    e,
-                                )
-                                "null"
-                            }
-                            methodChannel.invokeMethod("onSuccess", json)
-                        }
-
-                        is SmileIDResult.Error -> {
-                            // Print the stack trace, since we can't provide the actual Throwable
-                            // back to Flutter
-                            it.throwable.printStackTrace()
-                            methodChannel.invokeMethod("onError", it.throwable.message)
-                        }
-                    }
-                }
+    @Composable
+    override fun Content(args: Map<String, Any?>) {
+        SmileID.SmartSelfieAuthentication(
+            userId = args["userId"] as? String ?: randomUserId(),
+            jobId = args["jobId"] as? String ?: randomJobId(),
+            allowAgentMode = args["allowAgentMode"] as? Boolean ?: false,
+            showAttribution = args["showAttribution"] as? Boolean ?: true,
+        ) {
+            when (it) {
+                is SmileIDResult.Success -> onSuccess(it.data)
+                is SmileIDResult.Error -> onError(it.throwable)
             }
         }
     }
-
-    override fun getView() = view
-
-    override fun dispose() = Unit
 
     class Factory(
         private val messenger: BinaryMessenger,

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieEnrollment.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieEnrollment.kt
@@ -1,17 +1,13 @@
 package com.smileidentity.flutter
 
 import android.content.Context
-import android.view.View
-import androidx.compose.ui.platform.ComposeView
+import androidx.compose.runtime.Composable
 import com.smileidentity.SmileID
 import com.smileidentity.compose.SmartSelfieEnrollment
-import com.smileidentity.results.SmartSelfieResult
 import com.smileidentity.results.SmileIDResult
 import com.smileidentity.util.randomJobId
 import com.smileidentity.util.randomUserId
-import io.flutter.Log
 import io.flutter.plugin.common.BinaryMessenger
-import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
@@ -21,58 +17,26 @@ internal class SmileIDSmartSelfieEnrollment private constructor(
     viewId: Int,
     messenger: BinaryMessenger,
     args: Map<String, Any?>,
-) : PlatformView {
+) : SmileComposablePlatformView(context, VIEW_TYPE_ID, viewId, messenger, args) {
     companion object {
         const val VIEW_TYPE_ID = "SmileIDSmartSelfieEnrollment"
     }
 
-    private val methodChannel: MethodChannel
-    private val view: View
-
-    init {
-        methodChannel = MethodChannel(messenger, "${VIEW_TYPE_ID}_$viewId")
-        view = ComposeView(context).apply {
-            setContent {
-                SmileID.SmartSelfieEnrollment(
-                    userId = args["userId"] as? String ?: randomUserId(),
-                    jobId = args["jobId"] as? String ?: randomJobId(),
-                    allowAgentMode = args["allowAgentMode"] as? Boolean ?: false,
-                    showAttribution = args["showAttribution"] as? Boolean ?: true,
-                    showInstructions = args["showInstructions"] as? Boolean ?: true,
-                ) {
-                    when (it) {
-                        is SmileIDResult.Success -> {
-                            // At this point, we have a successful result from the native SDK. But,
-                            // there is still a possibility of the JSON serializing erroring for
-                            // whatever reason -- if such a thing happens, we still want to tell
-                            // the caller that the overall operation was successful. However, we
-                            // just may not be able to provide the result JSON.
-                            val json = try {
-                                SmileID.moshi
-                                    .adapter(SmartSelfieResult::class.java)
-                                    .toJson(it.data)
-                            } catch (e: Exception) {
-                                Log.e("SmileIDSmartSelfieEnrollment", "Error serializing result", e)
-                                "null"
-                            }
-                            methodChannel.invokeMethod("onSuccess", json)
-                        }
-
-                        is SmileIDResult.Error -> {
-                            // Print the stack trace, since we can't provide the actual Throwable
-                            // back to Flutter
-                            it.throwable.printStackTrace()
-                            methodChannel.invokeMethod("onError", it.throwable.message)
-                        }
-                    }
-                }
+    @Composable
+    override fun Content(args: Map<String, Any?>) {
+        SmileID.SmartSelfieEnrollment(
+            userId = args["userId"] as? String ?: randomUserId(),
+            jobId = args["jobId"] as? String ?: randomJobId(),
+            allowAgentMode = args["allowAgentMode"] as? Boolean ?: false,
+            showAttribution = args["showAttribution"] as? Boolean ?: true,
+            showInstructions = args["showInstructions"] as? Boolean ?: true,
+        ) {
+            when (it) {
+                is SmileIDResult.Success -> onSuccess(it.data)
+                is SmileIDResult.Error -> onError(it.throwable)
             }
         }
     }
-
-    override fun getView() = view
-
-    override fun dispose() = Unit
 
     class Factory(
         private val messenger: BinaryMessenger,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -181,7 +181,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "10.0.0-beta03"
+    version: "10.0.0-beta04"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smile_id
 description: The Official Smile ID Flutter SDK
-version: 10.0.0-beta03
+version: 10.0.0-beta04
 homepage: "https://usesmileid.com"
 
 environment:


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/11051

## Summary

This changes the ViewModelStoreOwner to be scoped to the lifecycle of the Composable rather than of the activity. This ensures ViewModel state is not shared between subsequent invocations. This wasn't happing in our own native sample app because we use a fully Composable app -- this issue arose only when dealing with the View<->Compose interop.

This also moves a lot of shared boilerplate into a new `SmileComposablePlatformView` abstract class