### PR TITLE
Automate release notes

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -1,0 +1,34 @@
+name: Post-Release Actions
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  update-docs-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout flutter
+        uses: actions/checkout@v4
+        with:
+          path: flutter
+      - name: Checkout docs
+        uses: actions/checkout@v4
+        with:
+          repository: smileidentity/docs
+          path: docs
+          token: ${{ secrets.GH_PAT }}
+      - name: Copy CHANGELOG.md to Release Notes
+        run: cp flutter/CHANGELOG.md docs/integration-options/mobile/flutter-v10/release-notes.md
+      - name: Create docs PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
+          path: docs
+          commit-message: Flutter ${{ github.event.release.tag_name }} Release Notes
+          title: Flutter ${{ github.event.release.tag_name }} Release Notes
+          body: Automated PR to update the release notes
+          branch: flutter-release-notes-${{ github.event.release.tag_name }}
+          labels: "release-notes"
+          team-reviewers: "smileidentity/mobile"

--- a/.github/workflows/release_android.yml
+++ b/.github/workflows/release_android.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           git checkout -b "android-${{ github.event.inputs.android_release_version }}"
           git push origin "android-${{ github.event.inputs.android_release_version }}"
-      - name: Read build.gradle
+      - name: Read version
         id: read-file
         run: |
           sed -i "s/\(version findProperty(\"SDK_VERSION\") ?: \).*/\1\"$(echo "${{ github.event.inputs.android_release_version }}" | cut -c 2-)\"/" android/build.gradle

--- a/.github/workflows/release_ios.yml
+++ b/.github/workflows/release_ios.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           git checkout -b "ios-${{ github.event.inputs.ios_release_version }}"
           git push origin "ios-${{ github.event.inputs.ios_release_version }}"
-      - name: Read build.gradle
+      - name: Read version
         id: read-file
         run: |
           sed -i "s/s.version\s*=\s*'[^']*'/s.version = '$(echo "${{ github.event.inputs.ios_release_version }}" | cut -c 2-)'/g" ios/smile_id.podspec

--- a/.github/workflows/release_sdk.yaml
+++ b/.github/workflows/release_sdk.yaml
@@ -19,4 +19,4 @@ jobs:
         with:
           channel: 'stable'
       - name: Publish package
-        run: dart pub publish -v -f
+        run: flutter pub publish -v -f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,71 +1,84 @@
-# Changelog
+# Release Notes
 
 ## 10.0.5
-- Fixed a bug where Android builds would not compile when the partner app (or a library they 
-  consume) also uses `Pigeon` under the hood
-- Bumped Android and iOS versions
+
+* Fixed a bug where Android builds would not compile when the partner app (or a library they consume) also uses `Pigeon` under the hood
+* Bumped Android and iOS versions
 
 ## 10.0.4
-- Support for Biometric KYC, exposed as a `SmileIDBiometricKYC` Widget
+
+* Support for Biometric KYC, exposed as a `SmileIDBiometricKYC` Widget
 
 ## 10.0.3
-- Added `allowNewEnroll` on SmartSelfie, BiometricKYC, DocV and EnhancedDocV
-- [iOS] Fixed missing callbackUrl
+
+* Added `allowNewEnroll` on SmartSelfie, BiometricKYC, DocV and EnhancedDocV
+* \[iOS] Fixed missing callbackUrl
 
 ## 10.0.2
-- Bump iOS SDK to 10.0.2 to fix white cutout issue on iOS 14 devices
+
+* Bump iOS SDK to 10.0.2 to fix white cutout issue on iOS 14 devices
 
 ## 10.0.1
-- Added `showInstructions` parameter to SmartSelfie Authentication
-- Fixed issue where `showInstructions` parameter was not respected on SmartSelfie Enrollment
+
+* Added `showInstructions` parameter to SmartSelfie Authentication
+* Fixed issue where `showInstructions` parameter was not respected on SmartSelfie Enrollment
 
 ## 10.0.0
-- No changes
+
+* No change
 
 ## 10.0.0-beta08
-- Add networking APIs
+
+* Add networking APIs
 
 ## 10.0.0-beta07
-- [Android] Added missing `showInstructions` on some Composables
-- [Android] Added missing proguard rule and updated consumer rules
-- [Android] Added missing parameters on Fragments
-- [Android] Fixed crash when duplicate images are attempted to be zipped
-- [Android] Fixed a bug where some attributes passed in were not respected
-- [Android] Fixed a bug when attempting to parcelize `SmileIDException`
-- [Android] Changed the OKHTTP call timeout to 60 seconds
-- [Android] Rename `partnerParams` to `extraPartnerParams`
-- [iOS] Consent Screen SwiftUI View
-- [iOS] Biometric KYC no longer bundles the Consent Screen
-- [iOS] Biometric KYC no longer bundles an ID Type selector or input
-- [Flutter] Fixed broken json decoding
+
+* \[Android] Added missing `showInstructions` on some Composables
+* \[Android] Added missing proguard rule and updated consumer rules
+* \[Android] Added missing parameters on Fragments
+* \[Android] Fixed crash when duplicate images are attempted to be zipped
+* \[Android] Fixed a bug where some attributes passed in were not respected
+* \[Android] Fixed a bug when attempting to parcelize `SmileIDException`
+* \[Android] Changed the OKHTTP call timeout to 60 seconds
+* \[Android] Rename `partnerParams` to `extraPartnerParams`
+* \[iOS] Consent Screen SwiftUI View
+* \[iOS] Biometric KYC no longer bundles the Consent Screen
+* \[iOS] Biometric KYC no longer bundles an ID Type selector or input
+* \[Flutter] Fixed broken json decoding
 
 ## 10.0.0-beta06
-- [Android] Added `extras` as optional params on all job types
-- [Android] Added `idAuthorityBypassPhoto` on Sandbox BiometricKYC jobs
-- [Android] Added `allowAgentMode` option on Document Verification and Enhanced Document Verification
-- [Flutter] Fixed wrong iOS decoding bug on success
+
+* \[Android] Added `extras` as optional params on all job types
+* \[Android] Added `idAuthorityBypassPhoto` on Sandbox BiometricKYC jobs
+* \[Android] Added `allowAgentMode` option on Document Verification and Enhanced Document Verification
+* \[Flutter] Fixed wrong iOS decoding bug on success
 
 ## 10.0.0-beta05
-- [Android] Fixed retry document submission on failed document submission
-- [Android] Fixed missing entered key in BiometricKYC
-- [Android] Added jobId on SmartSelfieEnrollmentFragment and SmartSelfieAuthenticationFragment
-- [Android] Added showInstructions on SmartSelfieEnrollmentFragment
-- [Android] Fix bug where showAttirubtion was not respected on the Consent Denied screen
-- [Android] Increased selfie capture resolution to 640px
-- [Android] Fixed a bug where the document preview showed a black box for some older devices
+
+* \[Android] Fixed retry document submission on failed document submission
+* \[Android] Fixed missing entered key in BiometricKYC
+* \[Android] Added jobId on SmartSelfieEnrollmentFragment and SmartSelfieAuthenticationFragment
+* \[Android] Added showInstructions on SmartSelfieEnrollmentFragment
+* \[Android] Fix bug where showAttirubtion was not respected on the Consent Denied screen
+* \[Android] Increased selfie capture resolution to 640px
+* \[Android] Fixed a bug where the document preview showed a black box for some older devices
 
 ## 10.0.0-beta04
-- [Android] Fix bug where Composable state did not get reset
+
+* \[Android] Fix bug where Composable state did not get reset
 
 ## 10.0.0-beta03
-- Allow setEnvironment({required bool useSandbox}) to enable sandbox or production environment
-- Allow setCallbackUrl({required Uri callbackUrl}) to set a callback url for all submitted jobs.
-- Bug Fixes and Improvements from iOS v10.0.0-beta10 and Android v10.0.0-beta09
+
+* Allow setEnvironment({required bool useSandbox}) to enable sandbox or production environment
+* Allow setCallbackUrl({required Uri callbackUrl}) to set a callback url for all submitted jobs.
+* Bug Fixes and Improvements from iOS v10.0.0-beta10 and Android v10.0.0-beta09
 
 ## 10.0.0-beta02
-- Support for Document Verification, exposed as a `SmileIDDocumentVerification` Widget
-- Support for SmartSelfie Authentication, exposed as a `SmileIDSmartSelfieAuthentication` Widget
+
+* Support for Document Verification, exposed as a `SmileIDDocumentVerification` Widget
+* Support for SmartSelfie Authentication, exposed as a `SmileIDSmartSelfieAuthentication` Widget
 
 ## 10.0.0-beta01
-- Initial release
-- Support for Enhanced KYC (Async)
+
+* Initial release
+* Support for Enhanced KYC (Async)


### PR DESCRIPTION
## Summary

Automates updating the Release Notes in our docs by copying over the changelog when a new release is created. GitBook uses a slightly different format, so I've replaced the current CHANGELOG.md with the current the GitBook contents. That will allow the diff to be only the new changes going forward. 

As always, the `## Unreleased` needs to be turned into an actual version number prior to performing a release. But even if forgotten, it can still be changed on the docs PR prior to merge.
