### PR TITLE
Prepare 10.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 10.0.7
+
+* Bump Android to 10.0.4 (https://github.com/smileidentity/android/releases/tag/v10.0.4)
+* Bump iOS to 10.0.8 (https://github.com/smileidentity/ios/releases/tag/v10.0.8)
+
 ## 10.0.6
 
 * Fixed a bug where Android builds would not compile when the partner app (or a library they consume) also uses `Pigeon` under the hood

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group "com.smileidentity.flutter"
-version findProperty("SDK_VERSION") ?: "10.0.3"
+version findProperty("SDK_VERSION") ?: "10.0.4"
 
 buildscript {
     ext.kotlin_version = "1.9.10"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smile_id
 description: The Official Smile ID Flutter SDK
-version: 10.0.6
+version: 10.0.7
 homepage: "https://usesmileid.com"
 
 environment:


### PR DESCRIPTION
iOS version was bumped in previous PRs (https://github.com/smileidentity/flutter/pull/54, https://github.com/smileidentity/flutter/pull/55)