### PR TITLE
update domain name

### DIFF
--- a/ios/smile_id.podspec
+++ b/ios/smile_id.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 A new Flutter project.
                        DESC
   s.homepage         = 'http://usesmileid.com'
-  s.author           = { 'Smile ID' => 'support@smileidentity.com' }
+  s.author           = { 'Smile ID' => 'support@usesmileid.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'


### PR DESCRIPTION
This PR updates smileidentity.com to usesmileid.com as part of the gradual transition to using the new domain name throughout the system.