### PR TITLE
Feature/smilescreens

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 10.1.10
+* Added selfie capture screens
+* Added document capture screens
+
 ## 10.1.9
 * Bump Android to 10.3.1 (https://github.com/smileidentity/android/releases/tag/v10.3.1)
 * Bump iOS to 10.2.10 (https://github.com/smileidentity/ios/releases/tag/v10.2.10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 10.1.10
 * Added selfie capture screens
 * Added document capture screens
+* Bump iOS to 10.2.12 (https://github.com/smileidentity/ios/releases/tag/v10.2.12)
 
 ## 10.1.9
 * Bump Android to 10.3.1 (https://github.com/smileidentity/android/releases/tag/v10.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Bump iOS to 10.2.12 (https://github.com/smileidentity/ios/releases/tag/v10.2.12)
 * Update AGP versions
 
-## 10.1.9
+## 10.1.9 
 * Bump Android to 10.3.1 (https://github.com/smileidentity/android/releases/tag/v10.3.1)
 * Bump iOS to 10.2.10 (https://github.com/smileidentity/ios/releases/tag/v10.2.10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added selfie capture screens
 * Added document capture screens
 * Bump iOS to 10.2.12 (https://github.com/smileidentity/ios/releases/tag/v10.2.12)
+* Update AGP versions
 
 ## 10.1.9
 * Bump Android to 10.3.1 (https://github.com/smileidentity/android/releases/tag/v10.3.1)

--- a/android/src/main/kotlin/com/smileidentity/flutter/Mapper.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/Mapper.kt
@@ -102,13 +102,15 @@ import com.smileidentity.models.v2.JobType as JobTypeV2
  *  The fix is these two helper functions to convert maps to nullable types, and vice versa
  */
 fun convertNullableMapToNonNull(map: Map<String?, String?>?): Map<String, String> =
-    map?.filterKeys { it != null }
+    map
+        ?.filterKeys { it != null }
         ?.filterValues { it != null }
         ?.mapKeys { it.key!! }
         ?.mapValues { it.value!! } ?: mapOf()
 
 fun convertNonNullMapToNullable(map: Map<String, String>): Map<String?, String?> =
-    map.mapKeys { it.key }
+    map
+        .mapKeys { it.key }
         .mapValues { it.value }
 
 fun FlutterJobType.toRequest() =
@@ -577,19 +579,24 @@ fun HostedWeb.toResponse() =
     FlutterHostedWeb(
         basicKyc = basicKyc.groupBy { it.countryCode }.mapValues { it.value.first().toResponse() },
         biometricKyc =
-            biometricKyc.groupBy { it.countryCode }
+            biometricKyc
+                .groupBy { it.countryCode }
                 .mapValues { it.value.first().toResponse() },
         enhancedKyc =
-            enhancedKyc.groupBy { it.countryCode }
+            enhancedKyc
+                .groupBy { it.countryCode }
                 .mapValues { it.value.first().toResponse() },
         documentVerification =
-            docVerification.groupBy { it.countryCode }
+            docVerification
+                .groupBy { it.countryCode }
                 .mapValues { it.value.first().toResponse() },
         enhancedKycSmartSelfie =
-            enhancedKycSmartSelfie.groupBy { it.countryCode }
+            enhancedKycSmartSelfie
+                .groupBy { it.countryCode }
                 .mapValues { it.value.first().toResponse() },
         enhancedDocumentVerification =
-            enhancedDocumentVerification.groupBy { it.countryCode }
+            enhancedDocumentVerification
+                .groupBy { it.countryCode }
                 .mapValues { it.value.first().toResponse() },
     )
 

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileComposablePlatformView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileComposablePlatformView.kt
@@ -81,7 +81,6 @@ internal abstract class SmileComposablePlatformView(
         methodChannel.invokeMethod("onSuccess", json)
     }
 
-
     /**
      * Delivers a successful result back to Flutter as JSON. It is the flutter code's responsibility
      * to parse this JSON string into the appropriate object

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileComposablePlatformView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileComposablePlatformView.kt
@@ -81,6 +81,17 @@ internal abstract class SmileComposablePlatformView(
         methodChannel.invokeMethod("onSuccess", json)
     }
 
+
+    /**
+     * Delivers a successful result back to Flutter as JSON. It is the flutter code's responsibility
+     * to parse this JSON string into the appropriate object
+     *
+     * @param result The success result string
+     */
+    fun onSuccessJson(result: String) {
+        methodChannel.invokeMethod("onSuccess", result)
+    }
+
     /**
      * Delivers an error result back to Flutter
      *

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
@@ -19,7 +19,6 @@ import com.smileidentity.compose.document.DocumentCaptureSide
 import com.smileidentity.compose.theme.colorScheme
 import com.smileidentity.flutter.utils.DocumentCaptureResultAdapter
 import com.smileidentity.util.randomJobId
-import com.squareup.moshi.JsonClass
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
@@ -28,7 +27,7 @@ import java.io.File
 
 data class DocumentCaptureResult(
     val documentFrontFile: File? = null,
-    val documentBackFile: File? = null
+    val documentBackFile: File? = null,
 )
 
 internal class SmileIDDocumentCaptureView private constructor(
@@ -45,11 +44,12 @@ internal class SmileIDDocumentCaptureView private constructor(
     override fun Content(args: Map<String, Any?>) {
         val colorScheme = SmileID.colorScheme.copy(background = Color.White)
         Box(
-            modifier = Modifier
-                .background(color = colorScheme.background)
-                .windowInsetsPadding(WindowInsets.statusBars)
-                .consumeWindowInsets(WindowInsets.statusBars)
-                .fillMaxSize(),
+            modifier =
+                Modifier
+                    .background(color = colorScheme.background)
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .consumeWindowInsets(WindowInsets.statusBars)
+                    .fillMaxSize(),
         ) {
             val jobId = args["jobId"] as? String ?: randomJobId()
             val front = args["front"] as? Boolean ?: true
@@ -58,27 +58,44 @@ internal class SmileIDDocumentCaptureView private constructor(
             val allowGalleryUpload = args["allowGalleryUpload"] as? Boolean ?: false
             val idAspectRatio = (args["idAspectRatio"] as Double?)?.toFloat()
             RenderDocumentCaptureScreen(
-                jobId, front, showInstructions,
-                showAttribution, allowGalleryUpload, idAspectRatio,
+                jobId,
+                front,
+                showInstructions,
+                showAttribution,
+                allowGalleryUpload,
+                idAspectRatio,
             )
         }
     }
 
-
-
     @Composable
     private fun RenderDocumentCaptureScreen(
-        jobId: String, front: Boolean,
-        showInstructions: Boolean, showAttribution: Boolean,
-        allowGalleryUpload: Boolean, idAspectRatio: Float?,
+        jobId: String,
+        front: Boolean,
+        showInstructions: Boolean,
+        showAttribution: Boolean,
+        allowGalleryUpload: Boolean,
+        idAspectRatio: Float?,
     ) {
         val hero = if (front) R.drawable.si_doc_v_front_hero else R.drawable.si_doc_v_back_hero
-        val instructionTitle = if (front) R.string.si_doc_v_instruction_title else
-            R.string.si_doc_v_instruction_back_title
-        val instructionSubTitle = if (front) R.string.si_verify_identity_instruction_subtitle else
-            R.string.si_doc_v_instruction_back_subtitle
-        val captureTitleText = if (front) R.string.si_doc_v_capture_instructions_front_title else
-            R.string.si_doc_v_capture_instructions_back_title
+        val instructionTitle =
+            if (front) {
+                R.string.si_doc_v_instruction_title
+            } else {
+                R.string.si_doc_v_instruction_back_title
+            }
+        val instructionSubTitle =
+            if (front) {
+                R.string.si_verify_identity_instruction_subtitle
+            } else {
+                R.string.si_doc_v_instruction_back_subtitle
+            }
+        val captureTitleText =
+            if (front) {
+                R.string.si_doc_v_capture_instructions_front_title
+            } else {
+                R.string.si_doc_v_capture_instructions_back_title
+            }
         DocumentCaptureScreen(
             jobId = jobId,
             side = if (front) DocumentCaptureSide.Front else DocumentCaptureSide.Back,
@@ -91,33 +108,39 @@ internal class SmileIDDocumentCaptureView private constructor(
             instructionsSubtitleText = stringResource(instructionSubTitle),
             captureTitleText = stringResource(captureTitleText),
             knownIdAspectRatio = idAspectRatio,
-            onConfirm = { file -> handleConfirmation(front,file) },
+            onConfirm = { file -> handleConfirmation(front, file) },
             onError = { throwable -> onError(throwable) },
             onSkip = { },
         )
     }
 
-    private fun handleConfirmation(front: Boolean,file: File) {
-        val newMoshi = SmileID.moshi.newBuilder()
-            .add(DocumentCaptureResultAdapter.FACTORY)
-            .build()
-        val result = DocumentCaptureResult(
-            documentFrontFile = if (front) file else null,
-            documentBackFile =  if (!front) file else null,
-        )
-        val json = try {
-            newMoshi
-                .adapter(DocumentCaptureResult::class.java)
-                .toJson(result)
-        } catch (e: Exception) {
-            onError(e)
-            return
-        }
+    private fun handleConfirmation(
+        front: Boolean,
+        file: File,
+    ) {
+        val newMoshi =
+            SmileID.moshi
+                .newBuilder()
+                .add(DocumentCaptureResultAdapter.FACTORY)
+                .build()
+        val result =
+            DocumentCaptureResult(
+                documentFrontFile = if (front) file else null,
+                documentBackFile = if (!front) file else null,
+            )
+        val json =
+            try {
+                newMoshi
+                    .adapter(DocumentCaptureResult::class.java)
+                    .toJson(result)
+            } catch (e: Exception) {
+                onError(e)
+                return
+            }
         json?.let {
             onSuccessJson(it)
         }
     }
-
 
     class Factory(
         private val messenger: BinaryMessenger,

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
@@ -53,14 +53,13 @@ internal class SmileIDDocumentCaptureView private constructor(
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                 ) {
-                    val jobId = randomJobId()
                     val isDocumentFrontSide = args["isDocumentFrontSide"] as? Boolean ?: true
                     val showInstructions = args["showInstructions"] as? Boolean ?: true
                     val showAttribution = args["showAttribution"] as? Boolean ?: true
                     val allowGalleryUpload = args["allowGalleryUpload"] as? Boolean ?: false
                     val idAspectRatio = (args["idAspectRatio"] as Double?)?.toFloat()
                     RenderDocumentCaptureScreen(
-                        jobId = jobId,
+                        jobId = randomJobId(),
                         isDocumentFrontSide = isDocumentFrontSide,
                         showInstructions = showInstructions,
                         showAttribution = showAttribution,

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
@@ -57,6 +57,7 @@ internal class SmileIDDocumentCaptureView private constructor(
                     val showInstructions = args["showInstructions"] as? Boolean ?: true
                     val showAttribution = args["showAttribution"] as? Boolean ?: true
                     val allowGalleryUpload = args["allowGalleryUpload"] as? Boolean ?: false
+                    val showConfirmationDialog = args["showConfirmationDialog"] as? Boolean ?: true
                     val idAspectRatio = (args["idAspectRatio"] as Double?)?.toFloat()
                     RenderDocumentCaptureScreen(
                         jobId = randomJobId(),
@@ -64,6 +65,7 @@ internal class SmileIDDocumentCaptureView private constructor(
                         showInstructions = showInstructions,
                         showAttribution = showAttribution,
                         allowGalleryUpload = allowGalleryUpload,
+                        showConfirmationDialog = showConfirmationDialog,
                         idAspectRatio = idAspectRatio,
                     )
                 }
@@ -78,6 +80,7 @@ internal class SmileIDDocumentCaptureView private constructor(
         showInstructions: Boolean,
         showAttribution: Boolean,
         allowGalleryUpload: Boolean,
+        showConfirmationDialog: Boolean,
         idAspectRatio: Float?,
     ) {
         val hero =
@@ -113,6 +116,7 @@ internal class SmileIDDocumentCaptureView private constructor(
             allowGallerySelection = allowGalleryUpload,
             showSkipButton = false,
             instructionsHeroImage = hero,
+            showConfirmation = showConfirmationDialog,
             instructionsTitleText = stringResource(instructionTitle),
             instructionsSubtitleText = stringResource(instructionSubTitle),
             captureTitleText = stringResource(captureTitleText),

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDPlugin.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDPlugin.kt
@@ -45,7 +45,10 @@ import java.net.URL
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
-class SmileIDPlugin : FlutterPlugin, SmileIDApi, ActivityAware {
+class SmileIDPlugin :
+    FlutterPlugin,
+    SmileIDApi,
+    ActivityAware {
     private var activity: Activity? = null
     private lateinit var appContext: Context
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
@@ -221,25 +224,26 @@ class SmileIDPlugin : FlutterPlugin, SmileIDApi, ActivityAware {
         callback: (Result<FlutterSmartSelfieResponse>) -> Unit,
     ) = launch(
         work = {
-            SmileID.api.doSmartSelfieEnrollment(
-                userId = userId,
-                selfieImage =
-                    File(selfieImage).asFormDataPart(
-                        partName = "selfie_image",
-                        mediaType = "image/jpeg",
-                    ),
-                livenessImages =
-                    livenessImages.map {
+            SmileID.api
+                .doSmartSelfieEnrollment(
+                    userId = userId,
+                    selfieImage =
                         File(selfieImage).asFormDataPart(
-                            partName = "liveness_images",
+                            partName = "selfie_image",
                             mediaType = "image/jpeg",
-                        )
-                    },
-                partnerParams = convertNullableMapToNonNull(partnerParams),
-                callbackUrl = callbackUrl,
-                sandboxResult = sandboxResult?.toInt(),
-                allowNewEnroll = allowNewEnroll,
-            ).toResponse()
+                        ),
+                    livenessImages =
+                        livenessImages.map {
+                            File(selfieImage).asFormDataPart(
+                                partName = "liveness_images",
+                                mediaType = "image/jpeg",
+                            )
+                        },
+                    partnerParams = convertNullableMapToNonNull(partnerParams),
+                    callbackUrl = callbackUrl,
+                    sandboxResult = sandboxResult?.toInt(),
+                    allowNewEnroll = allowNewEnroll,
+                ).toResponse()
         },
         callback = callback,
     )
@@ -257,24 +261,25 @@ class SmileIDPlugin : FlutterPlugin, SmileIDApi, ActivityAware {
         callback: (Result<FlutterSmartSelfieResponse>) -> Unit,
     ) = launch(
         work = {
-            SmileID.api.doSmartSelfieAuthentication(
-                userId = userId,
-                selfieImage =
-                    File(selfieImage).asFormDataPart(
-                        partName = "selfie_image",
-                        mediaType = "image/jpeg",
-                    ),
-                livenessImages =
-                    livenessImages.map {
+            SmileID.api
+                .doSmartSelfieAuthentication(
+                    userId = userId,
+                    selfieImage =
                         File(selfieImage).asFormDataPart(
-                            partName = "liveness_images",
+                            partName = "selfie_image",
                             mediaType = "image/jpeg",
-                        )
-                    },
-                partnerParams = convertNullableMapToNonNull(partnerParams),
-                callbackUrl = callbackUrl,
-                sandboxResult = sandboxResult?.toInt(),
-            ).toResponse()
+                        ),
+                    livenessImages =
+                        livenessImages.map {
+                            File(selfieImage).asFormDataPart(
+                                partName = "liveness_images",
+                                mediaType = "image/jpeg",
+                            )
+                        },
+                    partnerParams = convertNullableMapToNonNull(partnerParams),
+                    callbackUrl = callbackUrl,
+                    sandboxResult = sandboxResult?.toInt(),
+                ).toResponse()
         },
         callback = callback,
     )
@@ -405,8 +410,8 @@ class SmileIDPlugin : FlutterPlugin, SmileIDApi, ActivityAware {
         interval: Long,
         numAttempts: Long,
         transform: (ResponseType) -> FlutterResponseType,
-    ): FlutterResponseType {
-        return try {
+    ): FlutterResponseType =
+        try {
             val response =
                 withContext(Dispatchers.IO) {
                     apiCall(request, interval.milliseconds, numAttempts.toInt())
@@ -417,7 +422,6 @@ class SmileIDPlugin : FlutterPlugin, SmileIDApi, ActivityAware {
         } catch (e: Exception) {
             throw e
         }
-    }
 
     /**
      * https://stackoverflow.com/a/62206235

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieCaptureView.kt
@@ -57,37 +57,42 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
     override fun Content(args: Map<String, Any?>) {
         val colorScheme = SmileID.colorScheme.copy(background = Color.White)
         Box(
-            modifier = Modifier
-                .background(color = colorScheme.background)
-                .windowInsetsPadding(WindowInsets.statusBars)
-                .consumeWindowInsets(WindowInsets.statusBars)
-                .fillMaxSize(),
+            modifier =
+                Modifier
+                    .background(color = colorScheme.background)
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .consumeWindowInsets(WindowInsets.statusBars)
+                    .fillMaxSize(),
         ) {
             val userId = args["userId"] as? String ?: randomUserId()
             val jobId = args["jobId"] as? String ?: randomJobId()
             val showConfirmation = args["showConfirmation"] as? Boolean ?: true
             val allowAgentMode = args["allowAgentMode"] as? Boolean ?: true
             val metadata = LocalMetadata.current
-            val viewModel: SelfieViewModel = viewModel(
-                factory = viewModelFactory {
-                    SelfieViewModel(
-                        isEnroll = false,
-                        userId = userId,
-                        jobId = jobId,
-                        allowNewEnroll = false,
-                        skipApiSubmission = true,
-                        metadata = metadata,
-                    )
-                },
-            )
+            val viewModel: SelfieViewModel =
+                viewModel(
+                    factory =
+                        viewModelFactory {
+                            SelfieViewModel(
+                                isEnroll = false,
+                                userId = userId,
+                                jobId = jobId,
+                                allowNewEnroll = false,
+                                skipApiSubmission = true,
+                                metadata = metadata,
+                            )
+                        },
+                )
             val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
 
             when {
                 uiState.processingState != null -> HandleProcessingState(viewModel)
-                uiState.selfieToConfirm != null -> HandleSelfieConfirmation(
-                    showConfirmation,
-                    uiState, viewModel,
-                )
+                uiState.selfieToConfirm != null ->
+                    HandleSelfieConfirmation(
+                        showConfirmation,
+                        uiState,
+                        viewModel,
+                    )
 
                 else -> RenderSelfieCaptureScreen(userId, jobId, allowAgentMode, viewModel)
             }
@@ -102,15 +107,17 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
         viewModel: SelfieViewModel,
     ) {
         Box(
-            modifier = Modifier
-                .background(color = Color.White)
-                .windowInsetsPadding(WindowInsets.statusBars)
-                .consumeWindowInsets(WindowInsets.statusBars)
-                .fillMaxSize(),
+            modifier =
+                Modifier
+                    .background(color = Color.White)
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .consumeWindowInsets(WindowInsets.statusBars)
+                    .fillMaxSize(),
         ) {
             SelfieCaptureScreen(
-                modifier = Modifier
-                    .background(color = Color.White),
+                modifier =
+                    Modifier
+                        .background(color = Color.White),
                 userId = userId,
                 jobId = jobId,
                 allowAgentMode = allowAgentMode ?: true,
@@ -130,16 +137,27 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
         if (showConfirmation) {
             ImageCaptureConfirmationDialog(
                 titleText = stringResource(R.string.si_smart_selfie_confirmation_dialog_title),
-                subtitleText = stringResource(R.string.si_smart_selfie_confirmation_dialog_subtitle),
-                painter = BitmapPainter(
-                    BitmapFactory.decodeFile(uiState.selfieToConfirm!!.absolutePath)
-                        .asImageBitmap(),
-                ),
-                confirmButtonText = stringResource(R.string.si_smart_selfie_confirmation_dialog_confirm_button),
+                subtitleText =
+                    stringResource(
+                        R.string.si_smart_selfie_confirmation_dialog_subtitle,
+                    ),
+                painter =
+                    BitmapPainter(
+                        BitmapFactory
+                            .decodeFile(uiState.selfieToConfirm!!.absolutePath)
+                            .asImageBitmap(),
+                    ),
+                confirmButtonText =
+                    stringResource(
+                        R.string.si_smart_selfie_confirmation_dialog_confirm_button,
+                    ),
                 onConfirm = {
                     viewModel.submitJob()
                 },
-                retakeButtonText = stringResource(R.string.si_smart_selfie_confirmation_dialog_retake_button),
+                retakeButtonText =
+                    stringResource(
+                        R.string.si_smart_selfie_confirmation_dialog_retake_button,
+                    ),
                 onRetake = viewModel::onSelfieRejected,
                 scaleFactor = 1.25f,
             )
@@ -153,21 +171,25 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
         viewModel.onFinished { res ->
             when (res) {
                 is SmileIDResult.Success -> {
-                    val result = SmartSelfieCaptureResult(
-                        selfieFile = res.data.selfieFile,
-                        livenessFiles = res.data.livenessFiles,
-                    )
-                    val newMoshi = SmileID.moshi.newBuilder()
-                        .add(SelfieCaptureResultAdapter.FACTORY)
-                        .build()
-                    val json = try {
-                        newMoshi
-                            .adapter(SmartSelfieCaptureResult::class.java)
-                            .toJson(result)
-                    } catch (e: Exception) {
-                        onError(e)
-                        return@onFinished
-                    }
+                    val result =
+                        SmartSelfieCaptureResult(
+                            selfieFile = res.data.selfieFile,
+                            livenessFiles = res.data.livenessFiles,
+                        )
+                    val newMoshi =
+                        SmileID.moshi
+                            .newBuilder()
+                            .add(SelfieCaptureResultAdapter.FACTORY)
+                            .build()
+                    val json =
+                        try {
+                            newMoshi
+                                .adapter(SmartSelfieCaptureResult::class.java)
+                                .toJson(result)
+                        } catch (e: Exception) {
+                            onError(e)
+                            return@onFinished
+                        }
                     json?.let { js ->
                         onSuccessJson(js)
                     }

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieCaptureView.kt
@@ -2,16 +2,14 @@ package com.smileidentity.flutter
 
 import android.content.Context
 import android.graphics.BitmapFactory
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.res.stringResource
@@ -24,7 +22,9 @@ import com.smileidentity.compose.components.ImageCaptureConfirmationDialog
 import com.smileidentity.compose.components.LocalMetadata
 import com.smileidentity.compose.selfie.SelfieCaptureScreen
 import com.smileidentity.compose.theme.colorScheme
+import com.smileidentity.compose.theme.typography
 import com.smileidentity.flutter.utils.SelfieCaptureResultAdapter
+import com.smileidentity.models.v2.Metadata
 import com.smileidentity.results.SmileIDResult
 import com.smileidentity.util.randomJobId
 import com.smileidentity.util.randomUserId
@@ -36,16 +36,6 @@ import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
 import java.io.File
-import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import com.smileidentity.compose.theme.colorScheme
-import com.smileidentity.compose.theme.typography
-import androidx.compose.material3.Typography
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.toMutableStateList
-import com.smileidentity.models.v2.Metadata
 
 data class SmartSelfieCaptureResult(
     val selfieFile: File? = null,
@@ -70,9 +60,11 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
         ) {
             MaterialTheme(
                 colorScheme = SmileID.colorScheme,
-                typography = SmileID.typography
+                typography = SmileID.typography,
             ) {
-                Surface{
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                ) {
                     val userId = randomUserId()
                     val jobId = randomJobId()
                     val showConfirmationDialog = args["showConfirmationDialog"] as? Boolean ?: true
@@ -81,29 +73,38 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
                     val viewModel: SelfieViewModel =
                         viewModel(
                             factory =
-                            viewModelFactory {
-                                SelfieViewModel(
-                                    isEnroll = false,
-                                    userId = userId,
-                                    jobId = jobId,
-                                    allowNewEnroll = false,
-                                    skipApiSubmission = true,
-                                    metadata = metadata,
-                                )
-                            },
+                                viewModelFactory {
+                                    SelfieViewModel(
+                                        isEnroll = false,
+                                        userId = userId,
+                                        jobId = jobId,
+                                        allowNewEnroll = false,
+                                        skipApiSubmission = true,
+                                        metadata = metadata,
+                                    )
+                                },
                         )
                     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
 
                     when {
-                        uiState.processingState != null -> HandleProcessingState(viewModel)
+                        uiState.processingState != null ->
+                            HandleProcessingState(
+                                viewModel = viewModel,
+                            )
                         uiState.selfieToConfirm != null ->
                             HandleSelfieConfirmation(
-                                showConfirmationDialog,
-                                uiState,
-                                viewModel,
+                                showConfirmationDialog = showConfirmationDialog,
+                                uiState = uiState,
+                                viewModel = viewModel,
                             )
 
-                        else -> RenderSelfieCaptureScreen(userId, jobId, allowAgentMode, viewModel)
+                        else ->
+                            RenderSelfieCaptureScreen(
+                                userId = userId,
+                                jobId = jobId,
+                                allowAgentMode = allowAgentMode,
+                                viewModel = viewModel,
+                            )
                     }
                 }
             }
@@ -117,26 +118,15 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
         allowAgentMode: Boolean,
         viewModel: SelfieViewModel,
     ) {
-        Box(
-            modifier =
-                Modifier
-                    .background(color = Color.White)
-                    .windowInsetsPadding(WindowInsets.statusBars)
-                    .consumeWindowInsets(WindowInsets.statusBars)
-                    .fillMaxSize(),
-        ) {
-            SelfieCaptureScreen(
-                modifier =
-                    Modifier
-                        .background(color = Color.White),
-                userId = userId,
-                jobId = jobId,
-                allowAgentMode = allowAgentMode ?: true,
-                allowNewEnroll = false,
-                skipApiSubmission = true,
-                viewModel = viewModel,
-            )
-        }
+        SelfieCaptureScreen(
+            modifier = Modifier.fillMaxSize(),
+            userId = userId,
+            jobId = jobId,
+            allowAgentMode = allowAgentMode ?: true,
+            allowNewEnroll = false,
+            skipApiSubmission = true,
+            viewModel = viewModel,
+        )
     }
 
     @Composable

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieCaptureView.kt
@@ -177,14 +177,14 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
                             selfieFile = res.data.selfieFile,
                             livenessFiles = res.data.livenessFiles,
                         )
-                    val newMoshi =
+                    val moshi =
                         SmileID.moshi
                             .newBuilder()
                             .add(SelfieCaptureResultAdapter.FACTORY)
                             .build()
                     val json =
                         try {
-                            newMoshi
+                            moshi
                                 .adapter(SmartSelfieCaptureResult::class.java)
                                 .toJson(result)
                         } catch (e: Exception) {

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDSmartSelfieCaptureView.kt
@@ -79,16 +79,16 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
         val viewModel: SelfieViewModel =
             viewModel(
                 factory =
-                viewModelFactory {
-                    SelfieViewModel(
-                        isEnroll = false,
-                        userId = userId,
-                        jobId = jobId,
-                        allowNewEnroll = false,
-                        skipApiSubmission = true,
-                        metadata = metadata,
-                    )
-                },
+                    viewModelFactory {
+                        SelfieViewModel(
+                            isEnroll = false,
+                            userId = userId,
+                            jobId = jobId,
+                            allowNewEnroll = false,
+                            skipApiSubmission = true,
+                            metadata = metadata,
+                        )
+                    },
             )
         val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
         CompositionLocalProvider(
@@ -97,11 +97,12 @@ internal class SmileIDSmartSelfieCaptureView private constructor(
             MaterialTheme(colorScheme = SmileID.colorScheme, typography = SmileID.typography) {
                 Surface(content = {
                     when {
-                        showInstructions && !acknowledgedInstructions -> SmartSelfieInstructionsScreen(
-                            showAttribution = showAttribution,
-                        ) {
-                            acknowledgedInstructions = true
-                        }
+                        showInstructions && !acknowledgedInstructions ->
+                            SmartSelfieInstructionsScreen(
+                                showAttribution = showAttribution,
+                            ) {
+                                acknowledgedInstructions = true
+                            }
                         uiState.processingState != null -> HandleProcessingState(viewModel)
                         uiState.selfieToConfirm != null ->
                             HandleSelfieConfirmation(

--- a/android/src/main/kotlin/com/smileidentity/flutter/utils/DocumentCaptureResultAdapter.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/utils/DocumentCaptureResultAdapter.kt
@@ -1,0 +1,53 @@
+package com.smileidentity.flutter.utils
+import com.smileidentity.flutter.DocumentCaptureResult
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
+import java.io.File
+import java.lang.reflect.Type
+
+class DocumentCaptureResultAdapter : JsonAdapter<DocumentCaptureResult>() {
+
+    @FromJson
+    override fun fromJson(reader: JsonReader): DocumentCaptureResult {
+        reader.beginObject()
+        var frontFile: File? = null
+        var backFile: File? = null
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "documentFrontFile" -> frontFile = reader.nextString()?.let { File(it) }
+                "documentBackFile" -> backFile = reader.nextString()?.let { File(it) }
+                else -> reader.skipValue()
+            }
+        }
+        reader.endObject()
+        return DocumentCaptureResult(frontFile, backFile)
+    }
+
+    @ToJson
+    override fun toJson(writer: JsonWriter, value: DocumentCaptureResult?) {
+        if (value == null) {
+            writer.nullValue()
+            return
+        }
+        writer.beginObject()
+        writer.name("documentFrontFile").value(value.documentFrontFile?.absolutePath)
+        writer.name("documentBackFile").value(value.documentBackFile?.absolutePath)
+        writer.endObject()
+    }
+
+    companion object {
+        val FACTORY = object : Factory {
+            override fun create(
+                type: Type,
+                annotations: Set<Annotation>,
+                moshi: Moshi
+            ): JsonAdapter<*>? {
+                return if (type == DocumentCaptureResult::class.java) DocumentCaptureResultAdapter() else null
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/com/smileidentity/flutter/utils/DocumentCaptureResultAdapter.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/utils/DocumentCaptureResultAdapter.kt
@@ -10,7 +10,6 @@ import java.io.File
 import java.lang.reflect.Type
 
 class DocumentCaptureResultAdapter : JsonAdapter<DocumentCaptureResult>() {
-
     @FromJson
     override fun fromJson(reader: JsonReader): DocumentCaptureResult {
         reader.beginObject()
@@ -28,7 +27,10 @@ class DocumentCaptureResultAdapter : JsonAdapter<DocumentCaptureResult>() {
     }
 
     @ToJson
-    override fun toJson(writer: JsonWriter, value: DocumentCaptureResult?) {
+    override fun toJson(
+        writer: JsonWriter,
+        value: DocumentCaptureResult?,
+    ) {
         if (value == null) {
             writer.nullValue()
             return
@@ -40,14 +42,20 @@ class DocumentCaptureResultAdapter : JsonAdapter<DocumentCaptureResult>() {
     }
 
     companion object {
-        val FACTORY = object : Factory {
-            override fun create(
-                type: Type,
-                annotations: Set<Annotation>,
-                moshi: Moshi
-            ): JsonAdapter<*>? {
-                return if (type == DocumentCaptureResult::class.java) DocumentCaptureResultAdapter() else null
+        val FACTORY =
+            object : Factory {
+                override fun create(
+                    type: Type,
+                    annotations: Set<Annotation>,
+                    moshi: Moshi,
+                ): JsonAdapter<*>? =
+                    if (type ==
+                        DocumentCaptureResult::class.java
+                    ) {
+                        DocumentCaptureResultAdapter()
+                    } else {
+                        null
+                    }
             }
-        }
     }
 }

--- a/android/src/main/kotlin/com/smileidentity/flutter/utils/SelfieCaptureResultAdapter.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/utils/SelfieCaptureResultAdapter.kt
@@ -1,0 +1,67 @@
+package com.smileidentity.flutter.utils
+
+import com.smileidentity.flutter.SmartSelfieCaptureResult
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
+import java.io.File
+import java.lang.reflect.Type
+
+class SelfieCaptureResultAdapter : JsonAdapter<SmartSelfieCaptureResult>() {
+
+  @FromJson
+  override fun fromJson(reader: JsonReader): SmartSelfieCaptureResult {
+    reader.beginObject()
+    var selfieFile: File? = null
+    var livenessFiles: List<File>? = null
+    while (reader.hasNext()) {
+      when (reader.nextName()) {
+        "selfieFile" -> selfieFile = reader.nextString()?.let { File(it) }
+        "livenessFiles" -> {
+          reader.beginArray()
+          val files = mutableListOf<File>()
+          while (reader.hasNext()) {
+            reader.nextString()?.let { files.add(File(it)) }
+          }
+          reader.endArray()
+          livenessFiles = files
+        }
+        else -> reader.skipValue()
+      }
+    }
+    reader.endObject()
+    return SmartSelfieCaptureResult(selfieFile, livenessFiles)
+  }
+
+  @ToJson
+  override fun toJson(writer: JsonWriter, value: SmartSelfieCaptureResult?) {
+    if (value == null) {
+      writer.nullValue()
+      return
+    }
+    writer.beginObject()
+    writer.name("selfieFile").value(value.selfieFile?.absolutePath)
+    writer.name("livenessFiles")
+    writer.beginArray()
+    value.livenessFiles?.forEach { file ->
+      writer.value(file.absolutePath)
+    }
+    writer.endArray()
+    writer.endObject()
+  }
+
+  companion object {
+    val FACTORY = object : Factory {
+      override fun create(
+        type: Type,
+        annotations: Set<Annotation>,
+        moshi: Moshi
+      ): JsonAdapter<*>? {
+        return if (type == SmartSelfieCaptureResult::class.java) SelfieCaptureResultAdapter() else null
+      }
+    }
+  }
+}

--- a/android/src/main/kotlin/com/smileidentity/flutter/utils/SelfieCaptureResultAdapter.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/utils/SelfieCaptureResultAdapter.kt
@@ -11,57 +11,65 @@ import java.io.File
 import java.lang.reflect.Type
 
 class SelfieCaptureResultAdapter : JsonAdapter<SmartSelfieCaptureResult>() {
-
-  @FromJson
-  override fun fromJson(reader: JsonReader): SmartSelfieCaptureResult {
-    reader.beginObject()
-    var selfieFile: File? = null
-    var livenessFiles: List<File>? = null
-    while (reader.hasNext()) {
-      when (reader.nextName()) {
-        "selfieFile" -> selfieFile = reader.nextString()?.let { File(it) }
-        "livenessFiles" -> {
-          reader.beginArray()
-          val files = mutableListOf<File>()
-          while (reader.hasNext()) {
-            reader.nextString()?.let { files.add(File(it)) }
-          }
-          reader.endArray()
-          livenessFiles = files
+    @FromJson
+    override fun fromJson(reader: JsonReader): SmartSelfieCaptureResult {
+        reader.beginObject()
+        var selfieFile: File? = null
+        var livenessFiles: List<File>? = null
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "selfieFile" -> selfieFile = reader.nextString()?.let { File(it) }
+                "livenessFiles" -> {
+                    reader.beginArray()
+                    val files = mutableListOf<File>()
+                    while (reader.hasNext()) {
+                        reader.nextString()?.let { files.add(File(it)) }
+                    }
+                    reader.endArray()
+                    livenessFiles = files
+                }
+                else -> reader.skipValue()
+            }
         }
-        else -> reader.skipValue()
-      }
+        reader.endObject()
+        return SmartSelfieCaptureResult(selfieFile, livenessFiles)
     }
-    reader.endObject()
-    return SmartSelfieCaptureResult(selfieFile, livenessFiles)
-  }
 
-  @ToJson
-  override fun toJson(writer: JsonWriter, value: SmartSelfieCaptureResult?) {
-    if (value == null) {
-      writer.nullValue()
-      return
+    @ToJson
+    override fun toJson(
+        writer: JsonWriter,
+        value: SmartSelfieCaptureResult?,
+    ) {
+        if (value == null) {
+            writer.nullValue()
+            return
+        }
+        writer.beginObject()
+        writer.name("selfieFile").value(value.selfieFile?.absolutePath)
+        writer.name("livenessFiles")
+        writer.beginArray()
+        value.livenessFiles?.forEach { file ->
+            writer.value(file.absolutePath)
+        }
+        writer.endArray()
+        writer.endObject()
     }
-    writer.beginObject()
-    writer.name("selfieFile").value(value.selfieFile?.absolutePath)
-    writer.name("livenessFiles")
-    writer.beginArray()
-    value.livenessFiles?.forEach { file ->
-      writer.value(file.absolutePath)
-    }
-    writer.endArray()
-    writer.endObject()
-  }
 
-  companion object {
-    val FACTORY = object : Factory {
-      override fun create(
-        type: Type,
-        annotations: Set<Annotation>,
-        moshi: Moshi
-      ): JsonAdapter<*>? {
-        return if (type == SmartSelfieCaptureResult::class.java) SelfieCaptureResultAdapter() else null
-      }
+    companion object {
+        val FACTORY =
+            object : Factory {
+                override fun create(
+                    type: Type,
+                    annotations: Set<Annotation>,
+                    moshi: Moshi,
+                ): JsonAdapter<*>? =
+                    if (type ==
+                        SmartSelfieCaptureResult::class.java
+                    ) {
+                        SelfieCaptureResultAdapter()
+                    } else {
+                        null
+                    }
+            }
     }
-  }
 }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,7 +32,6 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-  pod 'SmileID', :path => '../../../ios/'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,6 +32,7 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
+  pod 'SmileID', :path => '../../../ios/'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -34,7 +34,6 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  pod 'SmileID', :path => '../../../ios/'
   target 'RunnerTests' do
     inherit! :search_paths
   end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -34,6 +34,7 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  pod 'SmileID', :path => '../../../ios/'
   target 'RunnerTests' do
     inherit! :search_paths
   end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -10,8 +10,8 @@ PODS:
   - lottie-ios (4.4.3)
   - smile_id (10.2.8):
     - Flutter
-    - SmileID (= 10.2.10)
-  - SmileID (10.2.10):
+    - SmileID (= 10.2.11)
+  - SmileID (10.2.11):
     - FingerprintJS
     - lottie-ios (~> 4.4.2)
     - ZIPFoundation (~> 0.9)
@@ -21,12 +21,12 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - smile_id (from `.symlinks/plugins/smile_id/ios`)
-  - SmileID (from `../../../ios/`)
 
 SPEC REPOS:
   trunk:
     - FingerprintJS
     - lottie-ios
+    - SmileID
     - ZIPFoundation
 
 EXTERNAL SOURCES:
@@ -36,18 +36,16 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   smile_id:
     :path: ".symlinks/plugins/smile_id/ios"
-  SmileID:
-    :path: "../../../ios/"
 
 SPEC CHECKSUMS:
   FingerprintJS: 96410117a394cca04d0f1e2374944c8697f2cceb
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 13825b8a9334a850581300559b8839134b124670
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
-  smile_id: a6900dadee005affe6dde86011b3cadddb1078d1
-  SmileID: b3f0d7f4740ed02fb96c29218e6620f4f511dfc4
+  smile_id: d4e2f5b739b8554c72e35b197a2ab3b25f1dc18e
+  SmileID: 6222ec839420b69917ae23ea11876d78d2529620
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: 7064edf3190eb3f2f35cbb863533a04d1a904a0a
+PODFILE CHECKSUM: 929954fb8941cef06249e96bd1516fd2a22ed7a5
 
 COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -10,8 +10,8 @@ PODS:
   - lottie-ios (4.4.3)
   - smile_id (10.2.11):
     - Flutter
-    - SmileID (= 10.2.11)
-  - SmileID (10.2.11):
+    - SmileID (= 10.2.12)
+  - SmileID (10.2.12):
     - FingerprintJS
     - lottie-ios (~> 4.4.2)
     - ZIPFoundation (~> 0.9)
@@ -21,12 +21,12 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - smile_id (from `.symlinks/plugins/smile_id/ios`)
-  - SmileID (from `../../../ios/`)
 
 SPEC REPOS:
   trunk:
     - FingerprintJS
     - lottie-ios
+    - SmileID
     - ZIPFoundation
 
 EXTERNAL SOURCES:
@@ -36,18 +36,16 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   smile_id:
     :path: ".symlinks/plugins/smile_id/ios"
-  SmileID:
-    :path: "../../../ios/"
 
 SPEC CHECKSUMS:
   FingerprintJS: 96410117a394cca04d0f1e2374944c8697f2cceb
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 13825b8a9334a850581300559b8839134b124670
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
-  smile_id: b96636dfddd232a4aba60963de7dcf954773737a
-  SmileID: 6222ec839420b69917ae23ea11876d78d2529620
+  smile_id: 2fee0f6ebcc325b3acada2728f9283c1244f32bb
+  SmileID: 6a7309335dafa915a23a6c4e8bfa4742aa483fc8
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: 6698faba2a215291d073ca608eb983ba29776d6e
+PODFILE CHECKSUM: 929954fb8941cef06249e96bd1516fd2a22ed7a5
 
 COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,12 +1,18 @@
 PODS:
+  - FingerprintJS (1.5.0):
+    - FingerprintJS/Core (= 1.5.0)
+  - FingerprintJS/Core (1.5.0):
+    - FingerprintJS/SystemControl
+  - FingerprintJS/SystemControl (1.5.0)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
   - lottie-ios (4.4.3)
   - smile_id (10.2.8):
     - Flutter
-    - SmileID (= 10.2.8)
-  - SmileID (10.2.8):
+    - SmileID (= 10.2.10)
+  - SmileID (10.2.10):
+    - FingerprintJS
     - lottie-ios (~> 4.4.2)
     - ZIPFoundation (~> 0.9)
   - ZIPFoundation (0.9.19)
@@ -15,11 +21,12 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - smile_id (from `.symlinks/plugins/smile_id/ios`)
+  - SmileID (from `../../../ios/`)
 
 SPEC REPOS:
   trunk:
+    - FingerprintJS
     - lottie-ios
-    - SmileID
     - ZIPFoundation
 
 EXTERNAL SOURCES:
@@ -29,15 +36,18 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   smile_id:
     :path: ".symlinks/plugins/smile_id/ios"
+  SmileID:
+    :path: "../../../ios/"
 
 SPEC CHECKSUMS:
+  FingerprintJS: 96410117a394cca04d0f1e2374944c8697f2cceb
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 13825b8a9334a850581300559b8839134b124670
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
-  smile_id: c1f326bef0b5ed738aaea3c7cb5ef6e768cb8e34
-  SmileID: 757fe12fe0101a707563abf51c4aa27fe5598994
+  smile_id: a6900dadee005affe6dde86011b3cadddb1078d1
+  SmileID: b3f0d7f4740ed02fb96c29218e6620f4f511dfc4
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: 929954fb8941cef06249e96bd1516fd2a22ed7a5
+PODFILE CHECKSUM: 7064edf3190eb3f2f35cbb863533a04d1a904a0a
 
 COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -21,12 +21,12 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - smile_id (from `.symlinks/plugins/smile_id/ios`)
+  - SmileID (from `../../../ios/`)
 
 SPEC REPOS:
   trunk:
     - FingerprintJS
     - lottie-ios
-    - SmileID
     - ZIPFoundation
 
 EXTERNAL SOURCES:
@@ -36,16 +36,18 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   smile_id:
     :path: ".symlinks/plugins/smile_id/ios"
+  SmileID:
+    :path: "../../../ios/"
 
 SPEC CHECKSUMS:
   FingerprintJS: 96410117a394cca04d0f1e2374944c8697f2cceb
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  integration_test: 13825b8a9334a850581300559b8839134b124670
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
   smile_id: b96636dfddd232a4aba60963de7dcf954773737a
   SmileID: 6222ec839420b69917ae23ea11876d78d2529620
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: 929954fb8941cef06249e96bd1516fd2a22ed7a5
+PODFILE CHECKSUM: 6698faba2a215291d073ca608eb983ba29776d6e
 
 COCOAPODS: 1.15.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -48,7 +48,6 @@
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		58F7E89A2A8AAD4200768A60 /* smile_config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = smile_config.json; sourceTree = SOURCE_ROOT; };
 		5C652CB71A7AB2429A3C6A10 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		61B805DA5C7C6EBD647CDE99 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -132,7 +131,6 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
-				58F7E89A2A8AAD4200768A60 /* smile_config.json */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0E26DE9A4BBFAB70477FC199 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAC1B1019A4344403D288225 /* Pods_RunnerTests.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		1E00B1732CAD9CCB005AF69D /* smile_config.json in Resources */ = {isa = PBXBuildFile; fileRef = 1E00B1722CAD9CCB005AF69D /* smile_config.json */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		5B80C33C8AA5AEC1DEEE0454 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B805DA5C7C6EBD647CDE99 /* Pods_Runner.framework */; };
@@ -45,6 +46,7 @@
 		14946750E16A70C02E2F3C34 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1E00B1722CAD9CCB005AF69D /* smile_config.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = smile_config.json; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
+				1E00B1722CAD9CCB005AF69D /* smile_config.json */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
@@ -215,7 +218,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {
@@ -259,6 +262,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1E00B1732CAD9CCB005AF69D /* smile_config.json in Resources */,
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		58F7E89B2A8AAD4200768A60 /* smile_config.json in Resources */ = {isa = PBXBuildFile; fileRef = 58F7E89A2A8AAD4200768A60 /* smile_config.json */; };
 		5B80C33C8AA5AEC1DEEE0454 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B805DA5C7C6EBD647CDE99 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -263,7 +262,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
-				58F7E89B2A8AAD4200768A60 /* smile_config.json in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -318,6 +318,7 @@ class MainContent extends StatelessWidget {
           MaterialPageRoute<void>(
             builder: (BuildContext context) => MyScaffold(
                 body: SmileIDDocumentCaptureView(
+                  isDocumentFrontSide: false,
                   showInstructions: true,
                   showAttribution: true,
                   allowGalleryUpload: false,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -286,7 +286,7 @@ class MainContent extends StatelessWidget {
           MaterialPageRoute<void>(
             builder: (BuildContext context) => MyScaffold(
                 body: SmileIDSmartSelfieCaptureView(
-              showConfirmation: true,
+              showConfirmationDialog: true,
               allowAgentMode: false,
               showAttribution: true,
               onSuccess: (String? result) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -287,8 +287,9 @@ class MainContent extends StatelessWidget {
             builder: (BuildContext context) => MyScaffold(
                 body: SmileIDSmartSelfieCaptureView(
               showConfirmationDialog: true,
-              allowAgentMode: false,
-              showAttribution: true,
+              showInstructions: true,
+              showAttribution: false,
+              allowAgentMode: true,
               onSuccess: (String? result) {
                 // Your success handling logic
                 Map<String, dynamic> jsonResult = json.decode(result ?? '{}');
@@ -318,25 +319,25 @@ class MainContent extends StatelessWidget {
           MaterialPageRoute<void>(
             builder: (BuildContext context) => MyScaffold(
                 body: SmileIDDocumentCaptureView(
-                  isDocumentFrontSide: false,
-                  showInstructions: true,
-                  showAttribution: true,
-                  allowGalleryUpload: false,
-                  onSuccess: (String? result) {
-                    // Your success handling logic
-                    Map<String, dynamic> jsonResult = json.decode(result ?? '{}');
-                    String formattedResult = jsonEncode(jsonResult);
-                    final snackBar = SnackBar(content: Text("Success: $formattedResult"));
-                    ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                    Navigator.of(context).pop();
-                  },
-                  onError: (String errorMessage) {
-                    // Your error handling logic
-                    final snackBar = SnackBar(content: Text("Error: $errorMessage"));
-                    ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                    Navigator.of(context).pop();
-                  },
-                )),
+              isDocumentFrontSide: true,
+              showInstructions: true,
+              showAttribution: false,
+              allowGalleryUpload: true,
+              onSuccess: (String? result) {
+                // Your success handling logic
+                Map<String, dynamic> jsonResult = json.decode(result ?? '{}');
+                String formattedResult = jsonEncode(jsonResult);
+                final snackBar = SnackBar(content: Text("Success: $formattedResult"));
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                Navigator.of(context).pop();
+              },
+              onError: (String errorMessage) {
+                // Your error handling logic
+                final snackBar = SnackBar(content: Text("Error: $errorMessage"));
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                Navigator.of(context).pop();
+              },
+            )),
           ),
         );
       },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -286,10 +286,10 @@ class MainContent extends StatelessWidget {
           MaterialPageRoute<void>(
             builder: (BuildContext context) => MyScaffold(
                 body: SmileIDSmartSelfieCaptureView(
-              showConfirmationDialog: true,
+              showConfirmationDialog: false,
               showInstructions: true,
               showAttribution: false,
-              allowAgentMode: true,
+              allowAgentMode: false,
               onSuccess: (String? result) {
                 // Your success handling logic
                 Map<String, dynamic> jsonResult = json.decode(result ?? '{}');
@@ -319,10 +319,11 @@ class MainContent extends StatelessWidget {
           MaterialPageRoute<void>(
             builder: (BuildContext context) => MyScaffold(
                 body: SmileIDDocumentCaptureView(
-              isDocumentFrontSide: true,
+              isDocumentFrontSide: false,
+              showConfirmationDialog: true,
               showInstructions: true,
               showAttribution: false,
-              allowGalleryUpload: true,
+              allowGalleryUpload: false,
               onSuccess: (String? result) {
                 // Your success handling logic
                 Map<String, dynamic> jsonResult = json.decode(result ?? '{}');

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -197,7 +197,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "10.1.8"
+    version: "10.1.10"
   source_span:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -98,30 +98,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  leak_tracker:
+  js:
     dependency: transitive
     description:
-      name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.5"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.1"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -134,42 +118,42 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -182,10 +166,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "4.2.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -210,18 +194,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -250,10 +234,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -266,18 +250,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: f3743ca475e0c9ef71df4ba15eb2d7684eecd5c8ba20a462462e4e8b561b2e11
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "11.6.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.0.5 <4.0.0"
+  flutter: ">=3.0.0"

--- a/ios/Classes/SmileIDDocumentCaptureView.swift
+++ b/ios/Classes/SmileIDDocumentCaptureView.swift
@@ -87,7 +87,7 @@ struct SmileIDDocumentRootView: View {
                 onError: didError,
                 onSkip: onSkip
             ).preferredColorScheme(.light)
-        }.environmentObject(localMetadata)
+        }.environmentObject(localMetadata).padding()}
     }
     
     func onConfirmed(data: Data) {

--- a/ios/Classes/SmileIDDocumentCaptureView.swift
+++ b/ios/Classes/SmileIDDocumentCaptureView.swift
@@ -83,6 +83,7 @@ struct SmileIDDocumentRootView: View {
                 ),
                 captureTitleText: SmileIDResourcesHelper.localizedString(for: "Action.TakePhoto"),
                 knownIdAspectRatio: idAspectRatio,
+                showConfirmation:showConfirmationDialog,
                 onConfirm: onConfirmed,
                 onError: didError,
                 onSkip: onSkip

--- a/ios/Classes/SmileIDDocumentCaptureView.swift
+++ b/ios/Classes/SmileIDDocumentCaptureView.swift
@@ -86,7 +86,7 @@ struct SmileIDDocumentRootView: View {
                 onConfirm: onConfirmed,
                 onError: didError,
                 onSkip: onSkip
-            )
+            ).preferredColorScheme(.light)
         }.environmentObject(localMetadata)
     }
     

--- a/ios/Classes/SmileIDDocumentCaptureView.swift
+++ b/ios/Classes/SmileIDDocumentCaptureView.swift
@@ -1,0 +1,172 @@
+import Flutter
+import SwiftUI
+import Combine
+import SmileID
+
+class SmileIDDocumentCaptureView: NSObject, FlutterPlatformView {
+    private let _childViewController: UIHostingController<AnyView>
+    private let _channel: FlutterMethodChannel
+    
+    static let VIEW_TYPE_ID = "SmileIDDocumentCaptureView"
+    
+    init(
+        frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: [String: Any?],
+        binaryMessenger messenger: FlutterBinaryMessenger
+    ) {
+
+        let front = args["front"] as? Bool ?? true
+        let jobId = args["jobId"] as? String ?? "job-\(UUID().uuidString)"
+        let showConfirmation = args["showConfirmation"] as? Bool ?? true
+        let showInstructions = args["showInstructions"] as? Bool ?? true
+        let showAttribution = args["showAttribution"] as? Bool ?? true
+        let allowGalleryUpload = args["allowGalleryUpload"] as? Bool ?? false
+        let idAspectRatio = args["idAspectRatio"] as? Double
+        
+        
+        self._channel = FlutterMethodChannel(
+            name: "\(SmileIDDocumentCaptureView.VIEW_TYPE_ID)_\(viewId)",
+            binaryMessenger: messenger
+        )
+        
+        let rootView = SmileIDDocumentRootView(
+            showConfirmation:showConfirmation,
+            front: front,
+            showInstructions: showInstructions,
+            showAttribution: showAttribution,
+            jobId: jobId,
+            idAspectRatio: idAspectRatio,
+            allowGalleryUpload: allowGalleryUpload,
+            channel: _channel)
+        self._childViewController = UIHostingController(rootView: AnyView(rootView))
+        
+        super.init()
+        
+        setupHostingController(frame: frame)
+    }
+    
+    private func setupHostingController(frame: CGRect) {
+        _childViewController.view.frame = frame
+        _childViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    }
+    
+    func view() -> UIView {
+        return _childViewController.view
+    }
+}
+
+struct SmileIDDocumentRootView: View {
+    let showConfirmation: Bool
+    let front: Bool
+    let showInstructions: Bool
+    let showAttribution: Bool
+    let jobId: String
+    let idAspectRatio: Double?
+    let allowGalleryUpload: Bool
+    let channel: FlutterMethodChannel
+    @State private var localMetadata = LocalMetadata()
+    
+    var body: some View {
+        NavigationView {
+            DocumentCaptureScreen(
+                side: front ? .front : .back,
+                showInstructions: showInstructions,
+                showAttribution: showAttribution,
+                allowGallerySelection: allowGalleryUpload,
+                showSkipButton: false,
+                instructionsHeroImage: front ? SmileIDResourcesHelper.DocVFrontHero : SmileIDResourcesHelper.DocVBackHero,
+                instructionsTitleText: SmileIDResourcesHelper.localizedString(
+                    for: front ? "Instructions.Document.Front.Header": "Instructions.Document.Back.Header"
+                ),
+                instructionsSubtitleText: SmileIDResourcesHelper.localizedString(
+                    for: front ? "Instructions.Document.Front.Callout": "Instructions.Document.Back.Callout"
+                ),
+                captureTitleText: SmileIDResourcesHelper.localizedString(for: "Action.TakePhoto"),
+                knownIdAspectRatio: idAspectRatio,
+                onConfirm: onConfirmed,
+                onError: didError,
+                onSkip: onSkip
+            )
+        }.environmentObject(localMetadata)
+    }
+    
+    func onConfirmed(data: Data) {
+        do {
+            // Attempt to create the document file
+            let url = try LocalStorage.createDocumentFile(
+                jobId:jobId,
+                fileType: front ? FileType.documentFront : FileType.documentBack,
+                document: data
+            )
+            
+            let documentKey = front ? "documentFrontImage" : "documentBackImage"
+            let arguments: [String: Any] = [
+                documentKey: url.absoluteString
+            ]
+            do {
+                let jsonData = try JSONSerialization.data(withJSONObject: arguments, options: [])
+                if let jsonString = String(data: jsonData, encoding: .utf8) {
+                    channel.invokeMethod("onSuccess", arguments: jsonString)
+                }
+            } catch {
+                didError(error: error)
+            }
+            
+        } catch {
+            didError(error: error)
+        }
+    }
+    
+    func onSkip() {
+        
+    }
+    
+    func didError(error: Error) {
+        channel.invokeMethod("onError", arguments: error.localizedDescription)
+    }
+    
+    
+    private func encodeToJSONString<T: Encodable>(_ value: T) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        guard let jsonData = try? encoder.encode(value) else { return nil }
+        return String(data: jsonData, encoding: .utf8)
+    }
+    
+    private func sendSuccessMessage(with arguments: [String: Any]) {
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: arguments, options: [])
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                channel.invokeMethod("onSuccess", arguments: jsonString)
+            }
+        } catch {
+            channel.invokeMethod("onError", arguments: error.localizedDescription)
+        }
+    }
+}
+
+// MARK: - Factory
+extension SmileIDDocumentCaptureView {
+    class Factory: NSObject, FlutterPlatformViewFactory {
+        private let messenger: FlutterBinaryMessenger
+        
+        init(messenger: FlutterBinaryMessenger) {
+            self.messenger = messenger
+            super.init()
+        }
+        
+        func create(withFrame frame: CGRect, viewIdentifier viewId: Int64, arguments args: Any?) -> FlutterPlatformView {
+            return SmileIDDocumentCaptureView(
+                frame: frame,
+                viewIdentifier: viewId,
+                arguments: args as? [String: Any?] ?? [:],
+                binaryMessenger: messenger
+            )
+        }
+        
+        func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+            return FlutterStandardMessageCodec.sharedInstance()
+        }
+    }
+}

--- a/ios/Classes/SmileIDDocumentCaptureView.swift
+++ b/ios/Classes/SmileIDDocumentCaptureView.swift
@@ -87,7 +87,7 @@ struct SmileIDDocumentRootView: View {
                 onError: didError,
                 onSkip: onSkip
             ).preferredColorScheme(.light)
-        }.environmentObject(localMetadata).padding()}
+        }.environmentObject(localMetadata).padding()
     }
     
     func onConfirmed(data: Data) {

--- a/ios/Classes/SmileIDPlugin.swift
+++ b/ios/Classes/SmileIDPlugin.swift
@@ -7,7 +7,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
         let messenger: FlutterBinaryMessenger = registrar.messenger()
         let api: SmileIDApi & NSObjectProtocol = SmileIDPlugin()
         SmileIDApiSetup.setUp(binaryMessenger: messenger, api: api)
-
+        
         let documentVerificationFactory = SmileIDDocumentVerification.Factory(
             messenger: registrar.messenger()
         )
@@ -15,7 +15,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             documentVerificationFactory,
             withId: SmileIDDocumentVerification.VIEW_TYPE_ID
         )
-
+        
         let enhancedDocumentVerificationFactory = SmileIDEnhancedDocumentVerification.Factory(
             messenger: registrar.messenger()
         )
@@ -23,7 +23,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             enhancedDocumentVerificationFactory,
             withId: SmileIDEnhancedDocumentVerification.VIEW_TYPE_ID
         )
-
+        
         let smartSelfieEnrollmentFactory = SmileIDSmartSelfieEnrollment.Factory(
             messenger: registrar.messenger()
         )
@@ -31,7 +31,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             smartSelfieEnrollmentFactory,
             withId: SmileIDSmartSelfieEnrollment.VIEW_TYPE_ID
         )
-
+        
         let smartSelfieAuthenticationFactory = SmileIDSmartSelfieAuthentication.Factory(
             messenger: registrar.messenger()
         )
@@ -39,13 +39,29 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             smartSelfieAuthenticationFactory,
             withId: SmileIDSmartSelfieAuthentication.VIEW_TYPE_ID
         )
-
+        
         let biometricKYCFactory = SmileIDBiometricKYC.Factory(
             messenger: registrar.messenger()
         )
         registrar.register(
             biometricKYCFactory,
             withId: SmileIDBiometricKYC.VIEW_TYPE_ID
+        )
+        
+        let selfieCaptureFactory = SmileIDSmartSelfieCaptureView.Factory(
+            messenger: registrar.messenger()
+        )
+        registrar.register(
+            selfieCaptureFactory,
+            withId: SmileIDSmartSelfieCaptureView.VIEW_TYPE_ID
+        )
+        
+        let documentCaptureFactory = SmileIDDocumentCaptureView.Factory(
+            messenger: registrar.messenger()
+        )
+        registrar.register(
+            documentCaptureFactory,
+            withId: SmileIDDocumentCaptureView.VIEW_TYPE_ID
         )
     }
     
@@ -80,35 +96,35 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             useSandbox: useSandbox
         )
     }
-
+    
     func setCallbackUrl(callbackUrl: String) {
         SmileID.setCallbackUrl(url: URL(string: callbackUrl))
     }
-
+    
     func setAllowOfflineMode(allowOfflineMode: Bool) {
         SmileID.setAllowOfflineMode(allowOfflineMode: allowOfflineMode)
     }
-
+    
     func getSubmittedJobs() -> [String] {
         SmileID.getSubmittedJobs()
     }
-
+    
     func getUnsubmittedJobs() -> [String] {
         SmileID.getUnsubmittedJobs()
     }
-
+    
     func cleanup(jobId: String) throws {
         try SmileID.cleanup(jobId: jobId)
     }
-
+    
     func cleanupJobs(jobIds: [String]) throws {
         try SmileID.cleanup(jobIds: jobIds)
     }
-
+    
     func submitJob(jobId: String, deleteFilesOnSuccess: Bool) throws {
         try SmileID.submitJob(jobId: jobId, deleteFilesOnSuccess: deleteFilesOnSuccess)
     }
-
+    
     func authenticate(
         request: FlutterAuthenticationRequest,
         completion: @escaping (Result<FlutterAuthenticationResponse, Error>) -> Void
@@ -122,7 +138,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func prepUpload(
         request: FlutterPrepUploadRequest,
         completion: @escaping (Result<FlutterPrepUploadResponse, Error>) -> Void
@@ -136,7 +152,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func upload(
         url : String,
         request : FlutterUploadRequest,
@@ -152,7 +168,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func doEnhancedKyc(
         request: FlutterEnhancedKycRequest,
         completion: @escaping (Result<FlutterEnhancedKycResponse, Error>) -> Void
@@ -166,7 +182,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func doEnhancedKycAsync(
         request: FlutterEnhancedKycRequest,
         completion: @escaping (Result<FlutterEnhancedKycAsyncResponse, Error>) -> Void
@@ -180,7 +196,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func doSmartSelfieEnrollment(
         signature: String,
         timestamp: String,
@@ -214,7 +230,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
                     partnerParams: convertNullableMapToNonNull(data: partnerParams),
                     callbackUrl: callbackUrl,
                     sandboxResult: sandboxResult.map { Int($0) },
-                    allowNewEnroll: allowNewEnroll
+                    allowNewEnroll: allowNewEnroll, metadata: Metadata.default()
                 )
                 completion(.success(response.toResponse()))
             } catch {
@@ -222,7 +238,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func doSmartSelfieAuthentication(
         signature: String,
         timestamp: String,
@@ -254,7 +270,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
                     },
                     partnerParams: convertNullableMapToNonNull(data: partnerParams),
                     callbackUrl: callbackUrl,
-                    sandboxResult: sandboxResult.map { Int($0) }
+                    sandboxResult: sandboxResult.map { Int($0) }, metadata: Metadata.default()
                 )
                 completion(.success(response.toResponse()))
             } catch {
@@ -262,7 +278,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func getSmartSelfieJobStatus(
         request: FlutterJobStatusRequest,
         completion: @escaping (Result<FlutterSmartSelfieJobStatusResponse, Error>) -> Void
@@ -276,7 +292,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func getDocumentVerificationJobStatus(
         request: FlutterJobStatusRequest,
         completion: @escaping (Result<FlutterDocumentVerificationJobStatusResponse, Error>) -> Void
@@ -290,7 +306,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func getBiometricKycJobStatus(
         request: FlutterJobStatusRequest,
         completion: @escaping (Result<FlutterBiometricKycJobStatusResponse, Error>) -> Void
@@ -304,7 +320,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func getEnhancedDocumentVerificationJobStatus(
         request: FlutterJobStatusRequest,
         completion: @escaping (Result<FlutterEnhancedDocumentVerificationJobStatusResponse, Error>) -> Void
@@ -318,7 +334,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func getProductsConfig(
         request: FlutterProductsConfigRequest,
         completion: @escaping (Result<FlutterProductsConfigResponse, Error>) -> Void
@@ -332,7 +348,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func getValidDocuments(
         request: FlutterProductsConfigRequest,
         completion: @escaping (Result<FlutterValidDocumentsResponse, Error>) -> Void
@@ -346,7 +362,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func getServices(
         completion: @escaping (Result<FlutterServicesResponse, Error>) -> Void
     ) {
@@ -359,7 +375,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func pollSmartSelfieJobStatus(
         request: FlutterJobStatusRequest,
         interval: Int64,
@@ -381,7 +397,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         )
     }
-
+    
     func pollDocumentVerificationJobStatus(
         request: FlutterJobStatusRequest,
         interval: Int64,
@@ -403,7 +419,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         )
     }
-
+    
     func pollBiometricKycJobStatus(
         request: FlutterJobStatusRequest,
         interval: Int64,
@@ -425,7 +441,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         )
     }
-
+    
     func pollEnhancedDocumentVerificationJobStatus(
         request: FlutterJobStatusRequest,
         interval: Int64,
@@ -447,7 +463,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         )
     }
-
+    
     func pollJobStatus<RequestType, T: JobResult>(
         apiCall: @escaping (RequestType, TimeInterval, Int) async throws -> AsyncThrowingStream<JobStatusResponse<T>, Error>,
         request: RequestType,
@@ -462,14 +478,14 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
                     completion(.failure(NSError(domain: "Invalid numAttempts value", code: -1, userInfo: nil)))
                     return
                 }
-
+                
                 let pollStream = try await apiCall(request, timeInterval, numAttemptsInt)
                 var result: JobStatusResponse<T>? = nil
-
+                
                 for try await res in pollStream {
                     result = res
                 }
-
+                
                 if let finalResult = result {
                     completion(.success(finalResult))
                 } else {
@@ -480,7 +496,7 @@ public class SmileIDPlugin: NSObject, FlutterPlugin, SmileIDApi {
             }
         }
     }
-
+    
     func convertToTimeInterval(milliSeconds: Int64) -> TimeInterval {
         let seconds = milliSeconds / 1000
         return TimeInterval(seconds)

--- a/ios/Classes/SmileIDSmartSelfieCaptureView.swift
+++ b/ios/Classes/SmileIDSmartSelfieCaptureView.swift
@@ -1,0 +1,162 @@
+import Flutter
+import SwiftUI
+import Combine
+import SmileID
+
+class SmileIDSmartSelfieCaptureView: NSObject, FlutterPlatformView {
+    private let _childViewController: UIHostingController<AnyView>
+    private let _viewModel: SelfieViewModel
+    private let _channel: FlutterMethodChannel
+    
+    static let VIEW_TYPE_ID = "SmileIDSmartSelfieCaptureView"
+    
+    init(
+        frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: [String: Any?],
+        binaryMessenger messenger: FlutterBinaryMessenger
+    ) {
+        let allowNewEnroll = args["allowNewEnroll"] as? Bool ?? false
+        let showConfirmation = args["showConfirmation"] as? Bool ?? false
+        
+        self._viewModel = SelfieViewModel(
+            isEnroll: false,
+            userId: args["userId"] as? String ?? "user-\(UUID().uuidString)",
+            jobId: args["jobId"] as? String ?? "job-\(UUID().uuidString)",
+            allowNewEnroll: allowNewEnroll,
+            skipApiSubmission: true,
+            extraPartnerParams: [:],
+            localMetadata: LocalMetadata()
+        )
+        
+        self._channel = FlutterMethodChannel(
+            name: "\(SmileIDSmartSelfieCaptureView.VIEW_TYPE_ID)_\(viewId)",
+            binaryMessenger: messenger
+        )
+        
+        let rootView = SmileIDRootView(viewModel: _viewModel, allowNewEnroll: allowNewEnroll, showConfirmation: showConfirmation, channel: _channel)
+        self._childViewController = UIHostingController(rootView: AnyView(rootView))
+        
+        super.init()
+        
+        setupHostingController(frame: frame)
+    }
+    
+    private func setupHostingController(frame: CGRect) {
+        _childViewController.view.frame = frame
+        _childViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    }
+    
+    func view() -> UIView {
+        return _childViewController.view
+    }
+}
+
+struct SmileIDRootView: View {
+    @ObservedObject var viewModel: SelfieViewModel
+    let allowNewEnroll: Bool
+    let showConfirmation: Bool
+    let channel: FlutterMethodChannel
+    
+    var body: some View {
+        NavigationView {
+            Group {
+                if viewModel.processingState != nil {
+                    Color.clear.onAppear {
+                        self.viewModel.onFinished(callback: self)
+                    }
+                } else if let selfieToConfirm = viewModel.selfieToConfirm, showConfirmation {
+                    ImageCaptureConfirmationDialog(
+                        title: SmileIDResourcesHelper.localizedString(for: "Confirmation.GoodSelfie"),
+                        subtitle: SmileIDResourcesHelper.localizedString(for: "Confirmation.FaceClear"),
+                        image: UIImage(data: selfieToConfirm)!,
+                        confirmationButtonText: SmileIDResourcesHelper.localizedString(for: "Confirmation.YesUse"),
+                        onConfirm: viewModel.submitJob,
+                        retakeButtonText: SmileIDResourcesHelper.localizedString(for: "Confirmation.Retake"),
+                        onRetake: viewModel.onSelfieRejected,
+                        scaleFactor: 1.25
+                    )
+                } else {
+                    SelfieCaptureScreen(
+                        allowAgentMode: allowNewEnroll,
+                        viewModel: viewModel
+                    )
+                }
+            }
+        }
+    }
+
+    
+    private func encodeToJSONString<T: Encodable>(_ value: T) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        guard let jsonData = try? encoder.encode(value) else { return nil }
+        return String(data: jsonData, encoding: .utf8)
+    }
+    
+    private func sendSuccessMessage(with arguments: [String: Any]) {
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: arguments, options: [])
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                channel.invokeMethod("onSuccess", arguments: jsonString)
+            }
+        } catch {
+            channel.invokeMethod("onError", arguments: error.localizedDescription)
+        }
+    }
+}
+
+extension SmileIDRootView: SmartSelfieResultDelegate {
+    func didSucceed(selfieImage: URL, livenessImages: [URL], apiResponse: SmartSelfieResponse?) {
+//        self.childViewController.removeFromParent()
+        var arguments: [String: Any] = [
+            "selfieFile": selfieImage.absoluteString,
+            "livenessFiles": livenessImages.map { $0.absoluteString }
+        ]
+        if let apiResponse = apiResponse {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            if let jsonData = try? encoder.encode(apiResponse),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                arguments["apiResponse"] = jsonString
+            }
+        }
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: arguments, options: [])
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                channel.invokeMethod("onSuccess", arguments: jsonString)
+            }
+        } catch {
+            didError(error: error)
+        }
+    }
+    
+    func didError(error: Error) {
+        channel.invokeMethod("onError", arguments: error.localizedDescription)
+    }
+}
+
+// MARK: - Factory
+extension SmileIDSmartSelfieCaptureView {
+    class Factory: NSObject, FlutterPlatformViewFactory {
+        private let messenger: FlutterBinaryMessenger
+        
+        init(messenger: FlutterBinaryMessenger) {
+            self.messenger = messenger
+            super.init()
+        }
+        
+        func create(withFrame frame: CGRect, viewIdentifier viewId: Int64, arguments args: Any?) -> FlutterPlatformView {
+            return SmileIDSmartSelfieCaptureView(
+                frame: frame,
+                viewIdentifier: viewId,
+                arguments: args as? [String: Any?] ?? [:],
+                binaryMessenger: messenger
+            )
+        }
+        
+        func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+            return FlutterStandardMessageCodec.sharedInstance()
+        }
+    }
+}

--- a/ios/Classes/SmileIDSmartSelfieCaptureView.swift
+++ b/ios/Classes/SmileIDSmartSelfieCaptureView.swift
@@ -80,12 +80,12 @@ struct SmileIDRootView: View {
                         retakeButtonText: SmileIDResourcesHelper.localizedString(for: "Confirmation.Retake"),
                         onRetake: viewModel.onSelfieRejected,
                         scaleFactor: 1.25
-                    )
+                    ).preferredColorScheme(.light)
                 } else {
                     SelfieCaptureScreen(
                         allowAgentMode: allowAgentMode,
                         viewModel: viewModel
-                    )
+                    ).preferredColorScheme(.light)
                 }
             }
         }

--- a/ios/smile_id.podspec
+++ b/ios/smile_id.podspec
@@ -15,7 +15,7 @@ A new Flutter project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   # NB! Update the s.version above when changing this version
-  s.dependency 'SmileID', '10.2.10'
+  s.dependency 'SmileID', '10.2.11'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/smile_id.podspec
+++ b/ios/smile_id.podspec
@@ -15,7 +15,7 @@ A new Flutter project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   # NB! Update the s.version above when changing this version
-  s.dependency 'SmileID', '10.2.8'
+  s.dependency 'SmileID', '10.2.10'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/smile_id.podspec
+++ b/ios/smile_id.podspec
@@ -15,7 +15,7 @@ A new Flutter project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   # NB! Update the s.version above when changing this version
-  s.dependency 'SmileID', '10.2.11'
+  s.dependency 'SmileID', '10.2.12'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/smile_id_document_capture_view.dart
+++ b/lib/smile_id_document_capture_view.dart
@@ -25,6 +25,7 @@ class SmileIDDocumentCaptureView extends StatelessWidget {
     bool showInstructions = true,
     bool showAttribution = true,
     bool allowGalleryUpload = true,
+    bool showConfirmationDialog = true,
     double? idAspectRatio,
     required Function(String resultJson) onSuccess,
     required Function(String errorMessage) onError,
@@ -37,6 +38,7 @@ class SmileIDDocumentCaptureView extends StatelessWidget {
         "showInstructions": showInstructions,
         "showAttribution": showAttribution,
         "allowGalleryUpload": allowGalleryUpload,
+        "showConfirmationDialog": showConfirmationDialog,
         "idAspectRatio": idAspectRatio,
       },
     );

--- a/lib/smile_id_document_capture_view.dart
+++ b/lib/smile_id_document_capture_view.dart
@@ -21,10 +21,7 @@ class SmileIDDocumentCaptureView extends StatelessWidget {
 
   factory SmileIDDocumentCaptureView({
     Key? key,
-    //jobId can't actually be null in the native SDK but we delegate creation to
-    // the native platform code, since that's where the random ID creation happens
-    String? jobId,
-    bool front = true,
+    bool isDocumentFrontSide = true,
     bool showInstructions = true,
     bool showAttribution = true,
     bool allowGalleryUpload = true,
@@ -36,8 +33,7 @@ class SmileIDDocumentCaptureView extends StatelessWidget {
       onSuccess: onSuccess,
       onError: onError,
       creationParams: {
-        "jobId": jobId,
-        "front": front,
+        "isDocumentFrontSide": isDocumentFrontSide,
         "showInstructions": showInstructions,
         "showAttribution": showAttribution,
         "allowGalleryUpload": allowGalleryUpload,

--- a/lib/smile_id_smart_selfie_capture_view.dart
+++ b/lib/smile_id_smart_selfie_capture_view.dart
@@ -21,9 +21,10 @@ class SmileIDSmartSelfieCaptureView extends StatelessWidget {
 
   factory SmileIDSmartSelfieCaptureView({
     Key? key,
-    bool showConfirmationDialog = false,
-    bool allowAgentMode = false,
+    bool showConfirmationDialog = true,
+    bool showInstructions = true,
     bool showAttribution = true,
+    bool allowAgentMode = true,
     required Function(String resultJson) onSuccess,
     required Function(String errorMessage) onError,
   }) {
@@ -32,8 +33,9 @@ class SmileIDSmartSelfieCaptureView extends StatelessWidget {
       onError: onError,
       creationParams: {
         "showConfirmationDialog": showConfirmationDialog,
-        "allowAgentMode": allowAgentMode,
+        "showInstructions": showInstructions,
         "showAttribution": showAttribution,
+        "allowAgentMode": allowAgentMode,
       },
     );
   }

--- a/lib/smile_id_smart_selfie_capture_view.dart
+++ b/lib/smile_id_smart_selfie_capture_view.dart
@@ -8,7 +8,7 @@ class SmileIDSmartSelfieCaptureView extends StatelessWidget {
   static const String viewType = "SmileIDSmartSelfieCaptureView";
   final Map<String, dynamic> creationParams;
 
-  /// Called when the user successfully completes the smart selfie enrollment flow. The result is a
+  /// Called when the user successfully completes the selfie capture flow. The result is a
   /// JSON string.
   final Function(String) onSuccess;
   final Function(String) onError;
@@ -21,11 +21,7 @@ class SmileIDSmartSelfieCaptureView extends StatelessWidget {
 
   factory SmileIDSmartSelfieCaptureView({
     Key? key,
-    // userId and jobId can't actually be null in the native SDK but we delegate their creation to
-    // the native platform code, since that's where the random ID creation happens
-    String? userId,
-    String? jobId,
-    bool showConfirmation = false,
+    bool showConfirmationDialog = false,
     bool allowAgentMode = false,
     bool showAttribution = true,
     Map<String, String>? extraPartnerParams,
@@ -36,9 +32,7 @@ class SmileIDSmartSelfieCaptureView extends StatelessWidget {
       onSuccess: onSuccess,
       onError: onError,
       creationParams: {
-        "userId": userId,
-        "jobId": jobId,
-        "showConfirmation": showConfirmation,
+        "showConfirmationDialog": showConfirmationDialog,
         "allowAgentMode": allowAgentMode,
         "showAttribution": showAttribution,
       },

--- a/lib/smile_id_smart_selfie_capture_view.dart
+++ b/lib/smile_id_smart_selfie_capture_view.dart
@@ -24,7 +24,6 @@ class SmileIDSmartSelfieCaptureView extends StatelessWidget {
     bool showConfirmationDialog = false,
     bool allowAgentMode = false,
     bool showAttribution = true,
-    Map<String, String>? extraPartnerParams,
     required Function(String resultJson) onSuccess,
     required Function(String errorMessage) onError,
   }) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smile_id
 description: The Official Smile ID Flutter SDK
-version: 10.1.9
+version: 10.1.10
 homepage: "https://usesmileid.com"
 
 environment:


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/13199/allow-wrappers-sdks-to-capture-face-images-separately-v10-react-vs-flutter

## Summary

Selfie capture UI without the whole flow and optionally can show or hide the confirmation dialog before returning the file paths

## Known Issues

Need to release https://github.com/smileidentity/ios/pull/231 for iOS to be complete 

## Test Instructions

There is a new button with title Selfie Capture click and capture should return the file paths on both android and iOS
1. Show attrition
2. Show confirmation
3. File paths should match the provided job id

## Screenshot


