### PR TITLE
Fix/screens on document capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 10.3.2
+* Fixed document capture view on android to properly handle showInstructions and showConfirmation 
+  screens
+
 ## 10.3.1
 
 * Fixed Moshi configuration to only use FileAdapter which uses absolute path

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,9 +92,10 @@ android {
         implementation "androidx.fragment:fragment-ktx"
         implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core"
         implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.8"
+        implementation "com.google.mlkit:object-detection:17.0.2"
 
         testImplementation "org.jetbrains.kotlin:kotlin-test"
-        testImplementation "io.mockk:mockk:1.13.11"
+        testImplementation "io.mockk:mockk:1.13.13"
     }
 }
 

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
@@ -1,18 +1,28 @@
 package com.smileidentity.flutter
 
 import android.content.Context
+import android.graphics.BitmapFactory
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.viewModelFactory
 import com.smileidentity.R
 import com.smileidentity.SmileID
+import com.smileidentity.compose.components.ImageCaptureConfirmationDialog
 import com.smileidentity.compose.components.LocalMetadata
+import com.smileidentity.compose.document.DocumentCaptureInstructionsScreen
 import com.smileidentity.compose.document.DocumentCaptureScreen
 import com.smileidentity.compose.document.DocumentCaptureSide
 import com.smileidentity.compose.theme.colorScheme
@@ -21,6 +31,7 @@ import com.smileidentity.flutter.results.DocumentCaptureResult
 import com.smileidentity.flutter.utils.DocumentCaptureResultAdapter
 import com.smileidentity.models.v2.Metadata
 import com.smileidentity.util.randomJobId
+import com.smileidentity.viewmodel.document.DocumentCaptureViewModel
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
@@ -92,9 +103,9 @@ internal class SmileIDDocumentCaptureView private constructor(
                             ) {
                                 acknowledgedInstructions = true
                             }
-                        showConfirmation && uiState.documentImageToConfirm != null ->
+                        showConfirmationDialog && uiState.documentImageToConfirm != null ->
                             RenderDocumentCaptureConfirmationScreen(
-                                documentImageToConfirm = uiState.documentImageToConfirm,
+                                documentImageToConfirm = uiState.documentImageToConfirm!!,
                                 isDocumentFrontSide = isDocumentFrontSide,
                                 viewModel = viewModel,
                             )
@@ -140,8 +151,8 @@ internal class SmileIDDocumentCaptureView private constructor(
         DocumentCaptureInstructionsScreen(
             modifier = Modifier.fillMaxSize(),
             heroImage = hero,
-            title = instructionTitle,
-            subtitle = instructionSubTitle,
+            title = stringResource(instructionTitle),
+            subtitle = stringResource(instructionSubTitle),
             showAttribution = showAttribution,
             allowPhotoFromGallery = allowGalleryUpload,
             showSkipButton = false,
@@ -160,7 +171,7 @@ internal class SmileIDDocumentCaptureView private constructor(
 
     @Composable
     private fun RenderDocumentCaptureConfirmationScreen(
-        documentImageToConfirm: File?,
+        documentImageToConfirm: File,
         isDocumentFrontSide: Boolean,
         viewModel: DocumentCaptureViewModel,
     ) {

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
@@ -36,6 +36,8 @@ import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
 import java.io.File
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 internal class SmileIDDocumentCaptureView private constructor(
     context: Context,
@@ -78,7 +80,9 @@ internal class SmileIDDocumentCaptureView private constructor(
                                 allowGalleryUpload = allowGalleryUpload,
                             ) { uri ->
                                 acknowledgedInstructions = true
-                                galleryDocumentUri = uri
+                                galleryDocumentUri = uri?.let {
+                                    URLDecoder.decode(it, StandardCharsets.UTF_8.toString())
+                                }
                             }
                         showConfirmation && documentImageToConfirm != null ->
                             RenderDocumentCaptureConfirmationScreen(
@@ -86,6 +90,13 @@ internal class SmileIDDocumentCaptureView private constructor(
                                 isDocumentFrontSide = isDocumentFrontSide,
                             ) {
                                 documentImageToConfirm = null
+
+                                // in case the user chooses to retake an image after a photo gallery
+                                // upload, we redirect the user to the instructions screen
+                                if (galleryDocumentUri != null) {
+                                    galleryDocumentUri = null
+                                    acknowledgedInstructions = false
+                                }
                             }
                         else -> RenderDocumentCaptureScreen(
                             isDocumentFrontSide = isDocumentFrontSide,
@@ -164,7 +175,7 @@ internal class SmileIDDocumentCaptureView private constructor(
                 handleConfirmation(isDocumentFrontSide, documentImageToConfirm)
             },
             retakeButtonText = stringResource(R.string.si_doc_v_confirmation_dialog_retake_button),
-            onRetake = onRetake, //viewModel::onRetry,
+            onRetake = onRetake,
             scaleFactor = 1.0f,
         )
     }

--- a/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
+++ b/android/src/main/kotlin/com/smileidentity/flutter/SmileIDDocumentCaptureView.kt
@@ -80,9 +80,10 @@ internal class SmileIDDocumentCaptureView private constructor(
                                 allowGalleryUpload = allowGalleryUpload,
                             ) { uri ->
                                 acknowledgedInstructions = true
-                                galleryDocumentUri = uri?.let {
-                                    URLDecoder.decode(it, StandardCharsets.UTF_8.toString())
-                                }
+                                galleryDocumentUri =
+                                    uri?.let {
+                                        URLDecoder.decode(it, StandardCharsets.UTF_8.toString())
+                                    }
                             }
                         showConfirmation && documentImageToConfirm != null ->
                             RenderDocumentCaptureConfirmationScreen(
@@ -98,14 +99,15 @@ internal class SmileIDDocumentCaptureView private constructor(
                                     acknowledgedInstructions = false
                                 }
                             }
-                        else -> RenderDocumentCaptureScreen(
-                            isDocumentFrontSide = isDocumentFrontSide,
-                            idAspectRatio = idAspectRatio,
-                            galleryDocumentUri = galleryDocumentUri,
-                            showConfirmation = showConfirmation,
-                        ) { file ->
-                            documentImageToConfirm = file
-                        }
+                        else ->
+                            RenderDocumentCaptureScreen(
+                                isDocumentFrontSide = isDocumentFrontSide,
+                                idAspectRatio = idAspectRatio,
+                                galleryDocumentUri = galleryDocumentUri,
+                                showConfirmation = showConfirmation,
+                            ) { file ->
+                                documentImageToConfirm = file
+                            }
                     }
                 }
             }
@@ -165,12 +167,14 @@ internal class SmileIDDocumentCaptureView private constructor(
             modifier = Modifier.fillMaxSize(),
             titleText = stringResource(R.string.si_doc_v_confirmation_dialog_title),
             subtitleText = stringResource(R.string.si_doc_v_confirmation_dialog_subtitle),
-            painter = BitmapPainter(
-                BitmapFactory
-                    .decodeFile(documentImageToConfirm.absolutePath)
-                    .asImageBitmap(),
-            ),
-            confirmButtonText = stringResource(R.string.si_doc_v_confirmation_dialog_confirm_button),
+            painter =
+                BitmapPainter(
+                    BitmapFactory
+                        .decodeFile(documentImageToConfirm.absolutePath)
+                        .asImageBitmap(),
+                ),
+            confirmButtonText =
+                stringResource(R.string.si_doc_v_confirmation_dialog_confirm_button),
             onConfirm = {
                 handleConfirmation(isDocumentFrontSide, documentImageToConfirm)
             },
@@ -195,17 +199,18 @@ internal class SmileIDDocumentCaptureView private constructor(
             } else {
                 DocumentCaptureSide.Back
             }
-        val captureTitleText = if (isDocumentFrontSide) {
-            R.string.si_doc_v_capture_instructions_front_title
-        } else {
-            R.string.si_doc_v_capture_instructions_back_title
-        }
+        val captureTitleText =
+            if (isDocumentFrontSide) {
+                R.string.si_doc_v_capture_instructions_front_title
+            } else {
+                R.string.si_doc_v_capture_instructions_back_title
+            }
         val viewModel: DocumentCaptureViewModel =
             DocumentCaptureViewModel(
                 jobId = jobId,
                 side = side,
                 knownAspectRatio = idAspectRatio,
-                metadata = LocalMetadata.current
+                metadata = LocalMetadata.current,
             )
         DocumentCaptureScreen(
             modifier = Modifier.fillMaxSize(),
@@ -222,7 +227,7 @@ internal class SmileIDDocumentCaptureView private constructor(
             },
             onError = { throwable -> onError(throwable) },
             galleryDocumentUri = galleryDocumentUri,
-            viewModel = viewModel
+            viewModel = viewModel,
         )
     }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -197,7 +197,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "10.3.1"
+    version: "10.3.2"
   source_span:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -197,7 +197,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "10.3.0"
+    version: "10.3.1"
   source_span:
     dependency: transitive
     description:
@@ -266,10 +266,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   webdriver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: smile_id
 description: The Official Smile ID Flutter SDK
-version: 10.3.1
+version: 10.3.2
 homepage: "https://usesmileid.com"
 
 environment:


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/14419/fix-confirmation-dialog-and-instruction-screen-options-are-not-handled-in-the-flutter-v10-2-1-release

## Summary

This PR fixes the document capture screen on android to properly handle the showInstructions and showConfirmation screens.

## Known Issues

On photo gallery upload the image seems to be rotated on the confirmation screen.

## Test Instructions


## Screenshot

