### PR TITLE
Feature: Add SafeArea Wrapper to Android Platform View Widget

### DIFF
--- a/lib/smile_id_biometric_kyc.dart
+++ b/lib/smile_id_biometric_kyc.dart
@@ -80,7 +80,8 @@ class SmileIDBiometricKYC extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return PlatformViewLink(
+        return SafeArea(
+          child: PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
@@ -105,7 +106,8 @@ class SmileIDBiometricKYC extends StatelessWidget {
               ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
               ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
               ..create();
-          },
+            },
+          ),
         );
       case TargetPlatform.iOS:
         return UiKitView(

--- a/lib/smile_id_document_capture_view.dart
+++ b/lib/smile_id_document_capture_view.dart
@@ -48,7 +48,8 @@ class SmileIDDocumentCaptureView extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return PlatformViewLink(
+        return SafeArea(
+          child: PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
@@ -73,7 +74,8 @@ class SmileIDDocumentCaptureView extends StatelessWidget {
               ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
               ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
               ..create();
-          },
+            },
+          ),
         );
       case TargetPlatform.iOS:
         return UiKitView(

--- a/lib/smile_id_document_verification.dart
+++ b/lib/smile_id_document_verification.dart
@@ -68,7 +68,8 @@ class SmileIDDocumentVerification extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return PlatformViewLink(
+        return SafeArea(
+          child: PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
@@ -94,6 +95,7 @@ class SmileIDDocumentVerification extends StatelessWidget {
               ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
               ..create();
           },
+          ),
         );
       case TargetPlatform.iOS:
         return UiKitView(

--- a/lib/smile_id_enhanced_document_verification.dart
+++ b/lib/smile_id_enhanced_document_verification.dart
@@ -75,7 +75,8 @@ class SmileIDEnhancedDocumentVerification extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return PlatformViewLink(
+        return SafeArea(
+          child: PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
@@ -101,6 +102,7 @@ class SmileIDEnhancedDocumentVerification extends StatelessWidget {
               ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
               ..create();
           },
+          ),
         );
       case TargetPlatform.iOS:
         return UiKitView(

--- a/lib/smile_id_smart_selfie_authentication.dart
+++ b/lib/smile_id_smart_selfie_authentication.dart
@@ -52,7 +52,8 @@ class SmileIDSmartSelfieAuthentication extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return PlatformViewLink(
+        return SafeArea(
+          child: PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
@@ -78,6 +79,7 @@ class SmileIDSmartSelfieAuthentication extends StatelessWidget {
               ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
               ..create();
           },
+          ),
         );
       case TargetPlatform.iOS:
         return UiKitView(

--- a/lib/smile_id_smart_selfie_authentication_enhanced.dart
+++ b/lib/smile_id_smart_selfie_authentication_enhanced.dart
@@ -50,7 +50,8 @@ class SmileIDSmartSelfieAuthenticationEnhanced extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return PlatformViewLink(
+        return SafeArea(
+          child: PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
@@ -75,7 +76,8 @@ class SmileIDSmartSelfieAuthenticationEnhanced extends StatelessWidget {
               ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
               ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
               ..create();
-          },
+            },
+          ),
         );
       case TargetPlatform.iOS:
         return UiKitView(

--- a/lib/smile_id_smart_selfie_capture_view.dart
+++ b/lib/smile_id_smart_selfie_capture_view.dart
@@ -46,7 +46,8 @@ class SmileIDSmartSelfieCaptureView extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return PlatformViewLink(
+        return SafeArea(
+          child: PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
@@ -71,7 +72,8 @@ class SmileIDSmartSelfieCaptureView extends StatelessWidget {
               ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
               ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
               ..create();
-          },
+            },
+          ),
         );
       case TargetPlatform.iOS:
         return UiKitView(

--- a/lib/smile_id_smart_selfie_enrollment.dart
+++ b/lib/smile_id_smart_selfie_enrollment.dart
@@ -52,7 +52,8 @@ class SmileIDSmartSelfieEnrollment extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return PlatformViewLink(
+        return SafeArea(
+          child: PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
@@ -78,6 +79,7 @@ class SmileIDSmartSelfieEnrollment extends StatelessWidget {
               ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
               ..create();
           },
+            ),
         );
       case TargetPlatform.iOS:
         return UiKitView(

--- a/lib/smile_id_smart_selfie_enrollment_enhanced.dart
+++ b/lib/smile_id_smart_selfie_enrollment_enhanced.dart
@@ -50,7 +50,8 @@ class SmileIDSmartSelfieEnrollmentEnhanced extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return PlatformViewLink(
+        return SafeArea(
+          child: PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
@@ -76,6 +77,7 @@ class SmileIDSmartSelfieEnrollmentEnhanced extends StatelessWidget {
               ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
               ..create();
           },
+          ),
         );
       case TargetPlatform.iOS:
         return UiKitView(


### PR DESCRIPTION
… Android

Story: https://app.shortcut.com/smileid/story/xxx

## Summary

- Wrapped the Android platform view implementation in a SafeArea widget to ensure proper handling of system UI boundaries
- The platform view now automatically respects status bars, navigation bars, notches, and other screen insets
- Change only affects Android platform implementation - iOS and other platforms remain unchanged

## Known Issues

None

## Test Instructions

Test with a device with 3 Button Navigation that is translucent to see if views are not drawn behind the navigation bar

## Screenshot

Before the  fix:
![Screenshot_20250614_234611](https://github.com/user-attachments/assets/e9dce22d-48c4-47cb-99c4-228d12a03c6f)

After the fix:
![Screenshot_20250615_000314](https://github.com/user-attachments/assets/5eaf09d6-7b24-4605-8108-5ce0e057b6a2)




If applicable (e.g. UI changes), add screenshots to help explain your work.
